### PR TITLE
reorder second level nav to match IA

### DIFF
--- a/templates/programmes/_nav_secondary.html
+++ b/templates/programmes/_nav_secondary.html
@@ -2,11 +2,11 @@
 		<li class="first{% if level_1 == 'programmes' and not level_2 %} active{% endif %}"><a href="/programmes">Overview</a></li>
 		<li{% if level_2 == 'public-cloud' %} class="active" {% endif %}><a href="/programmes/public-cloud">Public cloud</a></li>
 		<li{% if level_2 == 'openstack' %} class="active" {% endif %}><a href="/programmes/openstack">OpenStack</a></li>
+		<li{% if level_2 == 'charm' %} class="active" {% endif %}><a href="/programmes/charm">Charm</a></li>
 		<li{% if level_2 == 'software' %} class="active"{% endif %}><a href="/programmes/software">Software</a></li>
 		<li{% if level_2 == 'hardware' %} class="active"{% endif %}><a href="/programmes/hardware">Hardware</a></li>
 		<li{% if level_2 == 'phone' %} class="last-item active" {% endif %}><a href="/programmes/phone">Phone</a></li>
 		<li{% if level_2 == 'retail' %} class="active"{% endif %}><a href="/programmes/retail">Retail</a></li>
 		<li{% if level_2 == 'reseller' %} class="active" {% endif %}><a href="/programmes/reseller">Reseller</a></li>
 		<li{% if level_2 == 'iot' %} class="active" {% endif %}><a href="/programmes/iot">IoT</a></li>
-		<li{% if level_2 == 'charm' %} class="active" {% endif %}><a href="/programmes/charm">Charm</a></li>
 	</ul>


### PR DESCRIPTION
Done:
Reordered IA according to:
https://docs.google.com/a/canonical.com/drawings/d/1j8QeBuwDsM3aQSNQUPrXH5fiYLKEjSPtq9Wy9vO5cRE/edit

QA:
Check the ordering of the links in the second-level nav / dropdown against the IA doc.
