### PR TITLE
software page UX snags

### DIFF
--- a/templates/programmes/software.html
+++ b/templates/programmes/software.html
@@ -14,6 +14,7 @@
 		<h1>Ubuntu software partners</h1>
 		<p>Ubuntu has a thriving software ecosystem, with thousands of applications available for the PC, the server and the cloud &mdash; targeting both the enterprise and consumer markets. </p>
 		<p>We offer a range of benefits for ISVs looking to formalise their work with Ubuntu, through Canonical. As a certified partner, you&rsquo;ll get inside information on forthcoming Ubuntu developments, assistance in testing and optimising your applications with Ubuntu and OpenStack &mdash; and priority access to Ubuntu engineers.</p>
+		<p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
 	</div>
 	<img class="priority-0" src="https://assets.ubuntu.com/sites/ubuntu/latest/u/img/phone/scopes/image-scopes.jpg" alt="scopes">
 </section>

--- a/templates/templates/_contextual-footer.html
+++ b/templates/templates/_contextual-footer.html
@@ -15,7 +15,7 @@
 	{% elif level_1 == 'programmes' %}
 		{% if level_2 %}
 			<div class="feature-one six-col">
-				<h3>Get in touch</h3>
+				<h3>Become an Ubuntu partner</h3>
 				<p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
 				<p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
 			</div>
@@ -26,7 +26,7 @@
 			</div>
 		{% else %}
 			<div class="feature-one six-col">
-				<h3>Get in touch</h3>
+				<h3>Become an Ubuntu partner</h3>
 				<p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
 				<p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
 			</div>
@@ -60,7 +60,7 @@
 		</div>
 	{% else %}
 		<div class="feature-one six-col">
-			<h3>Get in touch</h3>
+			<h3>Become an Ubuntu partner</h3>
 			<p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p> 
 			<p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
 		</div>


### PR DESCRIPTION
Done:
Added a link to the contact us form on the software partners page
Updated the contextual footer wording for "get in touch"

QA:
Check the software partners page and see the get in touch link and check that the contextual footer has the heading "Become an Ubuntu partner"
