### PR TITLE
redirect /partner-programmes/phone-carrier to /programmes/phone

### DIFF
--- a/partnerwebsite/urls.py
+++ b/partnerwebsite/urls.py
@@ -33,6 +33,7 @@ urlpatterns = patterns(
     url(r'^partners.json$', partners_json_view),
     url(r'^customers.json$', customers_json_view),
     url(r'^programmes/?$', PartnerView.as_view()),
+    url(r'^partner-programmes/phone-carrier$', lambda r: HttpResponseRedirect('/programmes/phone')),
     url(r'^partner-programmes/?$', lambda r: HttpResponseRedirect('/programmes/')),
     url(r'^partner-programmes/(?P<name>[-\w]+)', lambda r, name: HttpResponseRedirect('/programmes/' + name)),
     url(r'^programmes/(?P<name>[-\w]+)', partner_programmes),


### PR DESCRIPTION
Done:
Redirected the phone page to its new URL.

QA:
go to /partner-programmes/phone-carrier and check that it redirects to /programmes/phone. Also check that other URLs work as expected.
