### PR TITLE
UX review tweaks

### DIFF
--- a/cms/views.py
+++ b/cms/views.py
@@ -105,11 +105,11 @@ def partner_programmes(request, name):
         ),
 
         "iot": base_partners.filter(
-            programme__name="IoT"
+            programme__name="Internet of Things"
         ),
 
         "charm": base_partners.filter(
-            programme__name="Charm"
+            programme__name="Charm Partner Programme"
         ),
     }
     distinct_partners = list(lookup_partners[name].distinct())

--- a/templates/programmes/charm.html
+++ b/templates/programmes/charm.html
@@ -5,7 +5,7 @@
 {% block meta_keywords %}Ubuntu, Canonical, partner, program, programme, partnership, ISV, independent, software, vendor, developer, publisher, application, app, service, global, local, cloud, server,   customer, client, OpenStack, Landscape, Juju, MAAS, IT, provider, open source, Linux, Big Data, cloud orchestration, charm, bundles, solutions, scale, integration, container, LXD, LXC, docker, scale out, bare metal{% endblock %}
 
 {% block second_level_nav_items %}
-	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Partner programmes" page_title="Charm" %}</nav>
+	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Programmes" page_title="Charm" %}</nav>
 {% endblock second_level_nav_items %}
 
 {% block content %}
@@ -20,7 +20,7 @@
 	</div>
 </section>
 
-{% include "block/_logo-list.html" with name="Charm partners" query="programme=charm" %}
+{% include "block/_logo-list.html" with name="Charm partners" query="programme=charm partner programme" %}
 
 <section class="row equal-height">
 	<div class="seven-col append-one">
@@ -28,7 +28,7 @@
 		<p>Juju automates and speeds up the deployment, scaling and managing of distributed applications. By creating a Juju charm for your product, you make it easy for administrators and devops teams to integrate it with hundreds of other solutions.</p>
 		<p>It gets better. Juju charms can be combined in bundles: if your software is usually deployed with other services,  a customer can use a charm bundle to deploy all the services together. All the detailed configuration settings and relationships between services are handled by Juju.</p>
 	</div>
-	<div class="four-col last-col align-vertically">
+	<div class="three-col last-col align-vertically">
 		<img src="https://assets.ubuntu.com/sites/ubuntu/latest/u/img/logos/logo-pack/logo-juju.svg" alt="Juju logo" />
 	</div>
 </section>
@@ -40,7 +40,7 @@
 	</div>
 	<div class="six-col">
 		<ul class="list-ubuntu">
-			<li>Inclusion in our <a href="https://jujucharms.com/">online charm database</a>, available for instant download</li>
+			<li>Inclusion in our <a href="https://jujucharms.com/" class="external">online charm database</a>, available for instant download</li>
 			<li>QA to ensure your charms meets the highest quality standards</li>
 		</ul>
 	</div>

--- a/templates/programmes/hardware.html
+++ b/templates/programmes/hardware.html
@@ -5,7 +5,7 @@
 {% block meta_keywords %}Ubuntu, Technical Partners,IHVs,Technical Partner program,Technical collaboration,technical partnership,Technical certification,Hardware,certification,driver support,driver certification,Canonical certification programs,component certification{% endblock %}
 
 {% block second_level_nav_items %}
-	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Partner programmes" page_title="Hardware" %}</nav>
+	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Programmes" page_title="Hardware" %}</nav>
 {% endblock second_level_nav_items %}
 
 {% block content %}

--- a/templates/programmes/index.html
+++ b/templates/programmes/index.html
@@ -5,7 +5,7 @@
 {% block meta_keywords %}Canonical, Ubuntu, partner, partnership, program, programme, carrier, telco, mobile, network, phone, smartphone, tablet, cloud, OpenStack, public cloud, infrastructure, guest, image, server, ISV, software, hardware, enablement, certify, certified, certification, PC, laptop, desktop, reseller, VAR, channel, developer{% endblock %}
 
 {% block second_level_nav_items %}
-	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Partner programmes" page_title="Overview" %}</nav>
+	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Programmes" page_title="Overview" %}</nav>
 {% endblock second_level_nav_items %}
 
 {% block content %}

--- a/templates/programmes/iot.html
+++ b/templates/programmes/iot.html
@@ -5,7 +5,7 @@
 {% block meta_keywords %}{% endblock %}
 
 {% block second_level_nav_items %}
-	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Partner programmes" page_title="Hardware" %}</nav>
+	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Programmes" page_title="Hardware" %}</nav>
 {% endblock second_level_nav_items %}
 
 {% block content %}
@@ -20,7 +20,7 @@
 	</div>
 </section>
 
-{% include "block/_logo-list.html" with name="Internet of Things partners" query="programme=iot" %}
+{% include "block/_logo-list.html" with name="Internet of Things partners" query="programme=internet of things" %}
 
 <section class="row">
 	<div class="eight-col">

--- a/templates/programmes/openstack.html
+++ b/templates/programmes/openstack.html
@@ -5,7 +5,7 @@
 {% block meta_keywords %}Cloud, OpenStack, Ubuntu, Server, Interoperability, testing, integration, ecosystem, UOIL, development, validation, affiliate, supporter, Technical Partner Progamme, lab, laboratory{% endblock %}
 
 {% block second_level_nav_items %}
-	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Partner programmes" page_title="OpenStack" %}</nav>
+	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Programmes" page_title="OpenStack" %}</nav>
 {% endblock second_level_nav_items %}
 
 {% block content %}

--- a/templates/programmes/phone.html
+++ b/templates/programmes/phone.html
@@ -5,7 +5,7 @@
 {% block meta_keywords %}CAG, Carrier Advisory Group, Ubuntu carrier, Ubuntu phone, Ubuntu mobile, Ubuntu smartphone, Ubuntu Touch, phone membership, mobile operators, carrier partners, mobile operator partners, ecosystem, app developers{% endblock %}
 
 {% block second_level_nav_items %}
-	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Partner programmes" page_title="Phone Carrier" %}</nav>
+	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Programmes" page_title="Phone Carrier" %}</nav>
 {% endblock second_level_nav_items %}
 
 {% block content %}

--- a/templates/programmes/public-cloud.html
+++ b/templates/programmes/public-cloud.html
@@ -5,7 +5,7 @@
 {% block meta_keywords %}CPC, Certified Public Cloud, cloud ecosystem, cloud partners, cloud tools, Juju, Charm, orchestration, Ubuntu cloud, guest, Canonical{% endblock %}
 
 {% block second_level_nav_items %}
-	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Partner programmes" page_title="Certified Public cloud" %}</nav>
+	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Programmes" page_title="Certified Public cloud" %}</nav>
 {% endblock second_level_nav_items %}
 
 {% block content %}

--- a/templates/programmes/reseller.html
+++ b/templates/programmes/reseller.html
@@ -5,7 +5,7 @@
 {% block meta_keywords %}Canonical, Ubuntu, partner, partnership, program, programme, carrier, telco, mobile, network, phone, smartphone, tablet, cloud, OpenStack, public cloud, infrastructure, guest, image, IaaS, PaaS, SaaS, server, ISV, IHV, OEM, ODM, software, hardware, enablement, certify, certified, certification, PC, laptop, desktop, reseller, VAR, channel, developer{% endblock %}
 
 {% block second_level_nav_items %}
-	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Partner programmes" page_title="Reseller" %}</nav>
+	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Programmes" page_title="Reseller" %}</nav>
 {% endblock second_level_nav_items %}
 
 {% block content %}

--- a/templates/programmes/retail.html
+++ b/templates/programmes/retail.html
@@ -8,7 +8,7 @@
 {% block meta_keywords %}Ubuntu, Dell, Asus, Lenovo, HP, retail, how to purchase, computer with Ubuntu, Mexico, France, India, China, Thailand, Indonesia, Russia, Brasil, Brazil, US, USA, Bodega Aurrera, online, Amazon, shop, store, where to buy{% endblock %}
 
 {% block second_level_nav_items %}
-	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Partner programmes" page_title="Retailer" %}</nav>
+	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Programmes" page_title="Retailer" %}</nav>
 {% endblock second_level_nav_items %}
 
 {% block content %}

--- a/templates/programmes/software.html
+++ b/templates/programmes/software.html
@@ -5,7 +5,7 @@
 {% block meta_keywords %}Ubuntu, Technical Partners,IHVs,Technical Partner program,Technical collaboration,technical partnership,Technical certification,software,certification,driver support,driver certification,Canonical certification programs,component certification{% endblock %}
 
 {% block second_level_nav_items %}
-	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Partner programmes" page_title="software" %}</nav>
+	<nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Programmes" page_title="software" %}</nav>
 {% endblock second_level_nav_items %}
 
 {% block content %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -64,7 +64,7 @@
 		<ul>
 			<li class="accessibility-aid"><a accesskey="s" href="#main-content">Jump to content</a></li>
 			<li>
-				<a class="first{% if level_1 == 'programmes' %} active{% endif %}" href="/programmes">Partner programmes</a>
+				<a class="first{% if level_1 == 'programmes' %} active{% endif %}" href="/programmes">Programmes</a>
 				{% include "programmes/_nav_secondary.html" with promo="true" %}
 			</li>
 			<li><a{% if level_1 == 'find-a-partner' %} class="active"{% endif %} href="/find-a-partner">Find a partner</a></li>


### PR DESCRIPTION
Done:
- updated the view to use the correct programme name for IoT
- Updated breadcrumb copy for all partner programme pages
- changed link to external class on the charm partner page
- shrunk the juju logo on the charm partner page
  QA:
  Check for the above changes in-browser
  You will need to create a "Internet of Things" programme and populate it with test data (the case of the programme name is important).
