### PR TITLE
add markdown to find-a-partner page

### DIFF
--- a/templates/find-a-partner/index.html
+++ b/templates/find-a-partner/index.html
@@ -1,5 +1,7 @@
 {% extends "templates/base_index.html" %}
 
+{% load markdown_deux_tags %}
+
 {% block title %}Find a partner | {% endblock %}
 {% block meta_description %}Browse current Ubuntu partners in hardware, software, mobile or cloud - or find a specific partner from the list.{% endblock %}
 {% block meta_keywords %}Canonical, Ubuntu, partner, partnership, program, programme, carrier, telco, mobile, network, phone, smartphone, tablet, cloud, OpenStack, public cloud, infrastructure, guest, image, server, ISV, software, hardware, enablement, certify, certified, certification, PC, laptop, desktop, reseller, VAR, channel, developer{% endblock %}
@@ -81,7 +83,7 @@
                 {{ p.name }}
                 {% endif %}
               </h3>
-              <p>{{ p.short_description }}</p>
+              <p>{{ p.short_description | markdown | linebreaks }}</p>
             </div>
             {% if p.logo %}
             {% endif %}


### PR DESCRIPTION
After clarification, the problem was markdown should be rendered on the find-a-partner page.
# QA

Add some markdown to a `Partner`'s `short_description`, then check it out on the find-a-partner page.
