### PR TITLE
Fix erronious "search" class in footer

### DIFF
--- a/templates/templates/_contextual-footer.html
+++ b/templates/templates/_contextual-footer.html
@@ -7,9 +7,9 @@
 			<p>Interested in becoming an Ubuntu partner? Learn more about the benefits of working with Canonical.</p> 
 			<p><a href="/programmes">See all partner programmes&nbsp;&rsaquo;</a></p>
 		</div>
-		<div class="feature-two six-col last-col search">
+		<div class="feature-two six-col last-col">
 			<h3>Find a partner</h3>
-			<p>Looking for a supplier with Ubuntu expertise? Search or select from the complete list of our partners.</p>
+			<p>Looking for a supplier with Ubuntu expertise? or select from the complete list of our partners.</p>
 			<p><a href="/find-a-partner">Browse partners&nbsp;&rsaquo;</a></p>
 		</div>
 	{% elif level_1 == 'programmes' %}
@@ -19,7 +19,7 @@
 				<p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
 				<p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
 			</div>
-			<div class="feature-two six-col last-col search">
+			<div class="feature-two six-col last-col">
 				<h3>Partner programmes</h3>
 				<p>Do you offer different services to your customers? Learn more about other Ubuntu partner engagements.</p>
 				<p><a href="/programmes">Find the right programme for you&nbsp;&rsaquo;</a></p>
@@ -30,9 +30,9 @@
 				<p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
 				<p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
 			</div>
-			<div class="feature-two six-col last-col search">
+			<div class="feature-two six-col last-col">
 				<h3>Find a partner</h3>
-				<p>Looking for a supplier with Ubuntu expertise? Search or select from the complete list of our partners.</p>
+				<p>Looking for a supplier with Ubuntu expertise? or select from the complete list of our partners.</p>
 				<p><a href="/find-a-partner">Find a partner&nbsp;&rsaquo;</a></p>
 			</div>
 		{% endif %}
@@ -42,7 +42,7 @@
 			<p>Interested in becoming a partner? Talk to us today for more information about our programmes and certification.</p>
 			<p><a href="/contact-us">Get in touch&nbsp;&rsaquo;</a></p>
 		</div>
-		<div class="feature-two six-col last-col search">
+		<div class="feature-two six-col last-col">
 			<h3>Get services and support</h3>
 			<p>Get on-site consulting services and training, direct from engineers involved in developing Ubuntu or subscribe to Ubuntu Advantage for systems management and support.</p>
 			<p><a href="www.ubuntu.com/management/ubuntu-advantage" class="external">Learn more about Ubuntu Advantage</a></p>
@@ -53,7 +53,7 @@
 			<p>If you’re in the industry and you&rsquo;re considering partnering with Canonical, please get in touch.</p> 
 			<p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
 		</div>
-		<div class="feature-two six-col last-col search">
+		<div class="feature-two six-col last-col">
 			<h3>Partner programmes</h3>
 			<p>Canonical operates a range of partner programmes that help OEMs, ODMs, ISVs, cloud operators and mobile carriers maximise the revenue opportunities Ubuntu provides.</p>
 			<p><a href="/programmes">Find the right programme for you&nbsp;&rsaquo;</a></p>
@@ -64,7 +64,7 @@
 			<p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p> 
 			<p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
 		</div>
-		<div class="feature-two six-col last-col search">
+		<div class="feature-two six-col last-col">
 			<h3>Partner programmes</h3>
 			<p>Do you offer different services to you customers? Learn more about other Ubuntu partner programmes.</p>
 			<p><a href="/programmes">Partner programmes&nbsp;&rsaquo;</a></p>


### PR DESCRIPTION
# QA

The second div in the footer should no longer have the `search` class applied, and render without the search icon overlay. (for original behaviour see the bottom of http://partners.ubuntu.com/find-a-partner)
