### PR TITLE
fixed query in partners.json

### DIFF
--- a/cms/views.py
+++ b/cms/views.py
@@ -21,7 +21,8 @@ def get_grouped_random_partners():
     """
 
     return Partner.objects.exclude(
-        partner_type__name="Customer",
+        partner_type__name="Customer"
+    ).exclude(
         programme__isnull=True,
         service_offered__isnull=True,
         technology__isnull=True


### PR DESCRIPTION
By spliting `published=True` out of `exclude()`
# QA
## TL;DR

Put in a few partners, observe that for published partners to appear in /partners.json, they need to have at least one of: [programme, service_offered, technology]
## Long explaination

In `http://localhost:8003/admincms/partner/add/`, create a Partner with dummy data, make sure the `published` checkbox is checked, and create one of `[programme, service_offered, technology]` is set, add dummy data as you see fit.
Partners should only appear in `/partners.json` if they are published and have at least one of `[programme, service_offered, technology]` set.
