### PR TITLE
Make short_description maximum 375 characters

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.core import serializers
 from django.db.models.signals import pre_save
 from django.template.defaultfilters import slugify
+from django.core.validators import MaxLengthValidator
 
 
 class PartnerModel(models.Model):
@@ -84,11 +85,12 @@ class Partner(PartnerModel):
     )
     short_description = models.TextField(
         help_text=(
-            "Used in search results, max 70 characters."
+            "Used in search results, max 375 characters."
             "(<a href='http://daringfireball.net/projects/markdown/basics'>"
             "Markdown formatted"
             "</a>)"
-        )
+        ),
+        validators=[MaxLengthValidator(375)]
     )
     long_description = models.TextField(
         blank=True, null=True,


### PR DESCRIPTION
As per [this bug](https://bugs.launchpad.net/ubuntu-partner-website/+bug/1492347),
enforce max length on `short_description` field, when saving.

This won't effect existing data, but it won't allow people to save any
changes to a partner until they reduce the description to less than 375
characters.
## QA

`make run`

Now browse to the edit page for the `Dell` partner, which should have
a short description of over 375 characters:
http://127.0.0.1:8003/admincms/partner/1/

Click "save", and you should get a validation error. Now delete the last
sentence from the short description and click "save" again - it should save
this time.
