### PR TITLE
Fix mobile styling for row-retailers

### DIFF
--- a/static/css/styles.scss
+++ b/static/css/styles.scss
@@ -506,14 +506,6 @@ html.opera-mini {
   float: left;
 }
 
-.row-retailers .twelve-col {
-  display: table;
-
-  .box {
-    display: table-cell;
-  }
-}
-
 /* @section logos
 -------------------------------------------------------------- */
 ul.inline-logos li img {

--- a/templates/programmes/retail.html
+++ b/templates/programmes/retail.html
@@ -42,7 +42,7 @@
 		</ul>
 	</div>
 </div>
-<div class="row row-retailers no-border">
+<div class="row no-border">
 	<h2>Our partnerships bring computers to retail</h2>
 	<div class="eight-col append-four">
 		<p>We&rsquo;ve been working with partners like Dell, HP  and Lenovo for years to ensure that Ubuntu devices reach market as effectively as possible. With the help of these partners, Ubuntu machines are distributed around the world and can be found in both their exclusive and partner stores.</p>


### PR DESCRIPTION
As per [this bug](https://bugs.launchpad.net/ubuntu-partner-website/+bug/1494967).
## QA

First look at http://partners.ubuntu.com/programmes/retail on a small screen
or a thin browser window - notice how the items under
"Our partnerships bring computers to retail" are squeezed.

Now run this branch (`make run`) and visit http://127.0.0.1:8003/programmes/retail
in a thin browser window. See how it all looks awesome.
