### PR TITLE
Fix 404 link to Ubuntu Advantage

### DIFF
--- a/templates/find-a-partner/index.html
+++ b/templates/find-a-partner/index.html
@@ -19,7 +19,7 @@
   </div>
 </div><!-- /row -->
 
-<div class="row">
+<div class="row no-border">
   <div class="search-panel three-col">
     <div class="twelve-col">
       <form>

--- a/templates/templates/_contextual-footer.html
+++ b/templates/templates/_contextual-footer.html
@@ -4,7 +4,7 @@
 	{% if level_1 == Null %}
 		<div class="feature-one six-col">
 			<h3>Partner programmes</h3>
-			<p>Interested in becoming an Ubuntu partner? Learn more about the benefits of working with Canonical.</p> 
+			<p>Interested in becoming an Ubuntu partner? Learn more about the benefits of working with Canonical.</p>
 			<p><a href="/programmes">See all partner programmes&nbsp;&rsaquo;</a></p>
 		</div>
 		<div class="feature-two six-col last-col">
@@ -45,12 +45,12 @@
 		<div class="feature-two six-col last-col">
 			<h3>Get services and support</h3>
 			<p>Get on-site consulting services and training, direct from engineers involved in developing Ubuntu or subscribe to Ubuntu Advantage for systems management and support.</p>
-			<p><a href="www.ubuntu.com/management/ubuntu-advantage" class="external">Learn more about Ubuntu Advantage</a></p>
+			<p><a href="http://www.ubuntu.com/management/ubuntu-advantage" class="external">Learn more about Ubuntu Advantage</a></p>
 		</div>
 	{% elif level_1 == 'partnering-with-us' %}
 		<div class="feature-one six-col">
 			<h3>Become a partner</h3>
-			<p>If you’re in the industry and you&rsquo;re considering partnering with Canonical, please get in touch.</p> 
+			<p>If you’re in the industry and you&rsquo;re considering partnering with Canonical, please get in touch.</p>
 			<p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
 		</div>
 		<div class="feature-two six-col last-col">
@@ -61,7 +61,7 @@
 	{% else %}
 		<div class="feature-one six-col">
 			<h3>Become an Ubuntu partner</h3>
-			<p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p> 
+			<p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
 			<p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
 		</div>
 		<div class="feature-two six-col last-col">


### PR DESCRIPTION
# Done
- Fixed the URL to Ubuntu Advantage in the contextual footer
- Remove border from row
## QA
- Run `make run`
- Go to `http://127.0.0.1:8003/find-a-partner?search=arm`
- Scroll to the bottom of the page
- Check the link "Learn more about Ubuntu Advantage" links to the correct page not a 404
- See there is no border touching the `<hr />`
### Details
- Card: https://canonical.leankit.com/Boards/View/111185042/119545555
- Bug: https://bugs.launchpad.net/ubuntu-website-content/+bug/1535363
