### PR TITLE
fix search magnifying glass

### DIFF
--- a/static/css/styles.scss
+++ b/static/css/styles.scss
@@ -551,9 +551,10 @@ ul.inline-logos li img {
 -------------------------------------------------------------- */
 .find-a-partner {
   .search {
+    background-image: url(http://www.canonical.com/static/img/pictograms/image-footer-search.svg);
     background-position: 7px 7px;
+    background-repeat: no-repeat;
     background-size: 20px;
-    background: url(http://www.canonical.com/static/img/pictograms/image-footer-search.svg) no-repeat;
     border: 1px solid $warm_grey;
     box-sizing: border-box;
     height: 36px;


### PR DESCRIPTION
### Done

Fixed the broken background-sizing for the search box on the find a partner page.
### QA

`make it so`
navigate to /find-a-partner and check that the search box is correctly styled
