### PR TITLE
add GA click events for the featured partner pages

### DIFF
--- a/templates/partner.html
+++ b/templates/partner.html
@@ -47,7 +47,7 @@
             {% endif %}
                 <h2>{{ text.fields.header }}</h2>
                 {{ text.fields.body|markdown }}
-                {% if text.fields.read_more_link %}<p><a href="{{ text.fields.read_more_link }}"{% if text.fields.read_more_cta %} class="link-cta-ubuntu"{% endif %}>{% if text.fields.read_more_link_text %}{{text.fields.read_more_link_text}}{% else %}Read more{% endif %}{% if not text.fields.read_more_cta %}&nbsp;&rsaquo;{% endif %}</a></p>{% endif %}
+                {% if text.fields.read_more_link %}<p><a href="{{ text.fields.read_more_link }}"{% if text.fields.read_more_cta %} class="link-cta-ubuntu"{% endif %} onclick="ga('send', 'event', 'External Link', '{{ partner.name }} partner page', 'From {{ partner.name }} partner page {{ text.fields.header }} row link');">{% if text.fields.read_more_link_text %}{{text.fields.read_more_link_text}}{% else %}Read more{% endif %}{% if not text.fields.read_more_cta %}&nbsp;&rsaquo;{% endif %}</a></p>{% endif %}
             </div>
             {% if forloop.counter|divisibleby:2 %}
             {% else %}
@@ -101,7 +101,7 @@
             <h2>Links</h2>
             <ul class="no-bullets">
                 {% for link in partner.links %}
-                <li><a class="external" href="{{ link.fields.url }}">{{ link.fields.text }}</a></li>
+                <li><a class="external" href="{{ link.fields.url }}" onclick="ga('send', 'event', 'External Link', '{{ partner.name }} partner page', 'From {{ partner.name }} partner page {{ link.fields.text }} link');">{{ link.fields.text }}</a></li>
                 {% endfor %}
             </ul>
         </div>


### PR DESCRIPTION
### Done

Added GA click events for all links on the partners page with suitable dynamic naming.
### QA

`make run`
Find a featured partner - e.g. IBM - and view their dedicated page - e.g. /ibm
Ensure that the links in any of the "texts" rows have GA events in their onclick actions.
