### PR TITLE
fix for lack of spacing between priority and normal results

### DIFF
--- a/static/css/styles.scss
+++ b/static/css/styles.scss
@@ -516,6 +516,12 @@ ul.inline-logos li img {
     border-color: $ubuntu_orange;
   }
 
+
+  .prioritisedResults li.last-item,
+  .prioritisedResults li:last-of-type {
+    margin-bottom: 20px;
+  }
+
   .results {
     .hide {
       display: none;

--- a/templates/find-a-partner/index.html
+++ b/templates/find-a-partner/index.html
@@ -56,7 +56,7 @@
             <p>Sorry, no partners matches found.</p>
             <p>Perhaps <a href="/find-a-partner">start your search again?</a></p>
         </div>
-        <div class="prioritisedResults"></div>
+        <ul class="prioritisedResults"></ul>
         {% if partners %}
         <ul>
             {% for p in partners %}


### PR DESCRIPTION
### Done

Fixed a bug where the last prioritised search result didn't have bottom border, collapsing the list into the normal results.
### QA

`make run`
Search for something resulting in prioritised results. e.g., /find-a-partner?search=microsoft
Ensure that there's a gap between the prioritised search results (with the search term in the name) and any other results.
