### PR TITLE
add amendments for the microsoft dedicated partner page

### DIFF
--- a/cms/migrations/0004_auto_20160331_1555.py
+++ b/cms/migrations/0004_auto_20160331_1555.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0003_auto_20160324_0920'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='text',
+            name='html_class',
+            field=models.CharField(help_text=b'The class added to the generated HTML for this section', max_length=200, blank=True),
+        ),
+        migrations.AddField(
+            model_name='text',
+            name='read_more_external',
+            field=models.BooleanField(default=False, help_text=b"Does the 'read more' link to an external site (other canonical sites or subdomains count as external)?"),
+        ),
+        migrations.AlterField(
+            model_name='text',
+            name='image_url',
+            field=models.URLField(help_text=b'A URL for an image to appear alongside the text', null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='text',
+            name='video_url',
+            field=models.URLField(help_text=b'A Youtube video URL.', null=True, blank=True),
+        ),
+    ]

--- a/cms/models.py
+++ b/cms/models.py
@@ -211,11 +211,18 @@ class Text(models.Model):
     partner = models.ForeignKey(Partner)
     header = models.TextField()
     body = models.TextField()
+    html_class = models.CharField(
+        max_length=200,
+        blank=True,
+        help_text="The class added to the generated HTML for this section"
+    )
     image_url = models.URLField(
-        help_text="A URL for an image to appear alongside the text"
+        help_text="A URL for an image to appear alongside the text",
+        blank=True,
+        null=True
     )
     video_url = models.URLField(
-        help_text="A Youtube video URL. Note: This will override any image for this text block.",
+        help_text="A Youtube video URL.",
         blank=True,
         null=True
     )
@@ -228,6 +235,12 @@ class Text(models.Model):
     read_more_cta = models.BooleanField(
         help_text=(
             "Should the 'read more' link be a CTA button?"
+        ),
+        default=False
+    )
+    read_more_external = models.BooleanField(
+        help_text=(
+            "Does the 'read more' link to an external site (other canonical sites or subdomains count as external)?"
         ),
         default=False
     )

--- a/static/css/styles.scss
+++ b/static/css/styles.scss
@@ -1771,3 +1771,82 @@ body.error-page {
     margin-top: -30px;
   }
 }
+
+.microsoft {
+  .banner {
+    box-shadow: none;
+  }
+
+  .hero {
+    background-image: url('https://assets.ubuntu.com/v1/518ad912-microsoft-build-conf.png?w=768');
+    background-repeat: no-repeat;
+    background-size: cover;
+
+    &--text {
+      background-color: rgba(255, 255, 255, .85);
+      max-width: 500px;
+      padding: 20px;
+    }
+  }
+
+  blockquote {
+    font-size: 1.1em;
+    line-height: 1.4em;
+    padding: 10px 20px;
+
+    p {
+
+      &::before {
+        color: $ubuntu-orange;
+        content: '“';
+        font-weight: bold;
+        margin-right: 2px;
+      }
+
+      &::after {
+        color: $ubuntu-orange;
+        content: '”';
+        font-weight: bold;
+        margin-left: 2px;
+      }
+    }
+  }
+
+  @media only screen and (min-width : 768px) {
+    .hero {
+      background-image: url('https://assets.ubuntu.com/v1/518ad912-microsoft-build-conf.png?w=984');
+      background-size: cover;
+      margin-top: -30px;
+      min-height: 42vw;
+
+      &--text {
+        background-color: rgba(255, 255, 255, .85);
+        margin: 50px 0 0 0;
+        padding: 40px;
+      }
+    }
+  }
+
+  @media only screen and (min-width : 984px) {
+    .hero {
+      background-image: url('https://assets.ubuntu.com/v1/518ad912-microsoft-build-conf.png?w=1500');
+    }
+  }
+
+  .azure-stack {
+    background-image: url('https://assets.ubuntu.com/v1/72be8745-azure-stack-hills.png');
+    background-position: 95% 100%;
+    background-repeat: no-repeat;
+    background-size: 100%;
+    padding-bottom: 220px;
+
+    @media only screen and (min-width : 768px) {
+      background-size: auto;
+      padding-bottom: 200px;
+    }
+
+    @media only screen and (min-width : 1400px) {
+      padding-bottom: 60px;
+    }
+  }
+}

--- a/templates/partner.html
+++ b/templates/partner.html
@@ -34,11 +34,11 @@
 
 {% if partner.texts %}
 {% for text in partner.texts|dictsort:"pk" %}
-<div class="row strip{% if forloop.counter|divisibleby:2 %} strip-light{% endif %} cms-text">
+<div class="row strip{% if forloop.counter|divisibleby:2 %} strip-light{% endif %} cms-text{% if text.fields.html_class%} {{ text.fields.html_class }}{% endif %}">
     <div class="strip-inner-wrapper">
-        <div class="twelve-col">
+        <div class="twelve-col equal-height">
             {% if forloop.counter|divisibleby:2 %}
-            <div class="four-col">
+            <div class="four-col align-center align-vertically">
                 {% if text.fields.image_url %}<img src="{{ text.fields.image_url }}" alt="" class="cms-text--image" />{% endif %}
             </div>
             <div class="eight-col last-col">
@@ -47,11 +47,11 @@
             {% endif %}
                 <h2>{{ text.fields.header }}</h2>
                 {{ text.fields.body|markdown }}
-                {% if text.fields.read_more_link %}<p><a href="{{ text.fields.read_more_link }}"{% if text.fields.read_more_cta %} class="link-cta-ubuntu"{% endif %} onclick="ga('send', 'event', 'External Link', '{{ partner.name }} partner page', 'From {{ partner.name }} partner page {{ text.fields.header }} row link');">{% if text.fields.read_more_link_text %}{{text.fields.read_more_link_text}}{% else %}Read more{% endif %}{% if not text.fields.read_more_cta %}&nbsp;&rsaquo;{% endif %}</a></p>{% endif %}
+                {% if text.fields.read_more_link %}<p><a href="{{ text.fields.read_more_link }}" class="{% if text.fields.read_more_cta %}link-cta-ubuntu"{% else %}{% if text.fields.read_more_external %} external{% endif %}{% endif %}" onclick="ga('send', 'event', 'External Link', '{{ partner.name }} partner page', 'From {{ partner.name }} partner page {{ text.fields.header }} row link');">{% if text.fields.read_more_link_text %}{{text.fields.read_more_link_text}}{% else %}Read more{% endif %}{% if not text.fields.read_more_cta and not text.fields.read_more_external %}&nbsp;&rsaquo;{% endif %}</a></p>{% endif %}
             </div>
             {% if forloop.counter|divisibleby:2 %}
             {% else %}
-            <div class="last-col four-col">
+            <div class="last-col four-col align-center align-vertically">
                 {% if text.fields.image_url %}<img src="{{ text.fields.image_url }}" alt="" class="cms-text--image" />{% endif %}
             </div>
             {% endif %}
@@ -71,7 +71,6 @@
             </div>
         </div>
         {% endif %}
-
     </div>
 </div>
 {% endfor %}


### PR DESCRIPTION
### Done

Added new enhancements to the dedicated partner pages and come styling specifically for Microsoft.
### QA
- `make clean-all` This will delete all data in your database!
- `make run`
- Go to /admin
- Find "Microsoft"
- make them a dedicated partner using the hidden-by-default "Detailed partner Information" dropdown (add a long description in the box too)
- add one or more "texts" using a variety of the options.
- specifically test a row with only the intro and body text and the HTML class "azure-stack" to see some microsoft-specific stying.

Test this at various viewports. Ask me if you want to see the site with the proposed live content.
