### PR TITLE
Create clear distinction for Insights reading list on /microsoft

### DIFF
--- a/templates/partner.html
+++ b/templates/partner.html
@@ -58,8 +58,10 @@
         </div>
         {% if text.fields.insights_tag %}
         <div class="row no-border">
-            <h3>Further reading</h3>
-            <div id="articles-{{ forloop.counter }}" class="twelve-col"></div>
+            <div class="six-col">
+                <h3>Further reading</h3>
+                <div id="articles-{{ forloop.counter }}"></div>
+            </div>
         </div>
         <script>
           $(window).load(function(){


### PR DESCRIPTION
## Done
- Added row around Insights blog feed
- Add heading 3 above feed "Further reading"
## QA
- Run code
- Browse to /microsoft
- Sync content with live DB (I had to do this manually)
- Check that Insights feed is as described and does not break across breakpoints
## Trello

https://trello.com/c/xPZYIwOR
