### PR TITLE
Implement django_yaml_redirects and add /programmes/reseller to redirects.yaml

### DIFF
--- a/partnerwebsite/urls.py
+++ b/partnerwebsite/urls.py
@@ -7,6 +7,8 @@ from django.template import RequestContext, loader, Context
 from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
 
+from django_yaml_redirects import load_redirects
+
 from cms.views import (
     partner_programmes, partner_view, PartnerView,
     find_a_partner, partners_json_view, customers_json_view
@@ -25,7 +27,9 @@ def handler500(request):
     t = loader.get_template('500.html')
     return HttpResponseServerError(t.render(Context({})))
 
-urlpatterns = patterns(
+urlpatterns = load_redirects()
+
+urlpatterns += patterns(
     '',
     url(r'^openid/', include('django_openid_auth.urls')),
     url(

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,0 +1,2 @@
+programmes/reseller/?: /programmes/channel
+

--- a/requirements/standard.txt
+++ b/requirements/standard.txt
@@ -10,6 +10,7 @@ dj-database-url==0.3.0
 dj-static==0.0.6
 python-openid==2.2.5
 django-static-root-finder==0.1.1
+django-yaml-redirects==0.4
 django-markdown-deux==1.0.5
 django-template-finder-view==0.2
 django-openid-auth==0.7


### PR DESCRIPTION
Fixes #87.
## QA

```
make clean-app && make stop clean-web run
```

When it's up and running, check http://127.0.0.1:8003/programmes/reseller redirects to http://127.0.0.1:8003/programmes/channel.
