### PR TITLE
copy update for /programmes

### DIFF
--- a/templates/programmes/index.html
+++ b/templates/programmes/index.html
@@ -62,8 +62,8 @@
             <p>We provide marketing materials to help retailers boost footfall, revenues and profits by selling PCs from the world&rsquo;s leading brands pre-loaded with Ubuntu.</p>
         </div>
         <div class="four-col box">
-            <h3><a href="/programmes/channel">Channel Partners&nbsp;&rsaquo;</a></h3>
-            <p>Channel Partners can expand their service portfolios with Ubuntu Advantage &mdash; management and support for Ubuntu.</p>
+            <h3><a href="/programmes/channel">Channel&nbsp;&rsaquo;</a></h3>
+            <p>Channel partners can expand their service portfolios with Ubuntu Advantage &mdash; management and support for Ubuntu.</p>
         </div>
         <div class="four-col last-col box">
             <h3><a href="/programmes/iot">Internet of Things (IoT)&nbsp;&rsaquo;</a></h3>


### PR DESCRIPTION
## Done

Changed references to Channel Partners to "Channel" or "Channel **p**artners" on /programmes
## QA

`make run`
Check that "Channel Partners" (upper-case P) doesn't appear on the page.
