### PR TITLE
add redirect from /amazon-web-services-llc to /aws

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,2 +1,2 @@
 programmes/reseller/?: /programmes/channel
-
+amazon-web-services-llc: /aws


### PR DESCRIPTION
++++ DO NOT MERGE ++++
## Done

Added a redirect from /amazon-web-services-llc redirects to /aws
## QA

`make run`
Check that the URL /amazon-web-services-llc redirects to /aws
