### PR TITLE
Fix URL for RSS feed - tag->tags

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -206,7 +206,7 @@ core.autoLastItem = function() {
 loadRSSFeed = function(id, tag, limit, url, title) {
   var feedURL = "https://insights.ubuntu.com/feed/";
   if (tag) {
-    feedURL += "?tag=" + tag;
+    feedURL += "?tags=" + tag;
   }
 
   if (limit) {


### PR DESCRIPTION
## Done

Corrected the URL for insights feeds to use "tags" rather than "tag" as a parameter
## QA

The feed JS won't work on local machines but you can check that the correct URL - with "tags" - is being called (and rejected for being cross-site)
