### PR TITLE
add aws redirects with trailing slashes

### DIFF
--- a/partnerwebsite/urls.py
+++ b/partnerwebsite/urls.py
@@ -65,5 +65,5 @@ urlpatterns += patterns(
     url(r'^thank-you$', PartnerView.as_view()),
     url(r'^find-a-partner$', find_a_partner),
     url(r'^partnering-with-us$', PartnerView.as_view()),
-    url(r'^(?P<slug>[-\w]+)$', partner_view),
+    url(r'^(?P<slug>[-\w]+)/?$', partner_view),
 )

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,4 +1,2 @@
 programmes/reseller/?: /programmes/channel
-amazon-web-services-llc: /aws
-amazon-web-services-llc/: /aws
-aws/: /aws
+amazon-web-services-llc/?: /aws


### PR DESCRIPTION
## Done

Added redirects for /amazon-web-services-llc/ and /aws/ to redirect to /aws
## QA

Go to /amazon-web-services-llc/ and /aws/ and see that they are redirected to /aws (it's fine it they're 404s on your local install)
