### PR TITLE
remove the 's' from 'tags' in the insights RSS feed URL

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -206,7 +206,7 @@ core.autoLastItem = function() {
 loadRSSFeed = function(id, tag, limit, url, title) {
   var feedURL = "https://insights.ubuntu.com/feed/";
   if (tag) {
-    feedURL += "?tags=" + tag;
+    feedURL += "?tag=" + tag;
   }
 
   if (limit) {


### PR DESCRIPTION
## Done

Removed the "s" from "tags=" in the javascript that builds the insights RSS feed URL on generated partner pages
