### PR TITLE
Fix link generation on partner logo block

### DIFF
--- a/templates/programmes/public-cloud.html
+++ b/templates/programmes/public-cloud.html
@@ -54,7 +54,7 @@
     </div>
 </div>
 
-{% include "block/_logo-list.html" with name="public cloud partners" extra_class="no-border" link="?programme=certified-public-cloud" %}
+{% include "block/_logo-list.html" with name="public cloud partners" extra_class="no-border" query="programme=certified-public-cloud" %}
 
 {% include "templates/_contextual-footer.html" %}
 


### PR DESCRIPTION
## Done

Fixed the partner search link generated on /public-cloud
## QA
- Go to /public-cloud 
- See that the "See all public cloud partners ›" link now has a query string (compare with live)
## Issue / Card

Fixes #96 
