### PR TITLE
Remove unneeded set conversion from programmes list

### DIFF
--- a/cms/views.py
+++ b/cms/views.py
@@ -145,7 +145,7 @@ def partner_programmes(request, name):
             programme__name="Charm partner programme"
         ),
     }
-    distinct_partners = list(set(lookup_partners[name]))
+    distinct_partners = list(lookup_partners[name])
     partners = distinct_partners[:max_num_of_partners]
     context = {'programme_partners': partners}
 


### PR DESCRIPTION
Remove set conversion which loses the ordering of the QueryList.
This change makes it forget which items are always_featured in the
beginning.

This should fix #108, so that always featured items are first in the list.