### PR TITLE
Add form validation to block http assets

### DIFF
--- a/cms/admin.py
+++ b/cms/admin.py
@@ -1,5 +1,9 @@
 from django.contrib import admin
 
+from cms.forms import (
+    PartnerForm,
+    TextForm,
+)
 from cms.models import (
     Partner, Technology, PartnerType, Programme, ServiceOffered,
     Quote, Link, InsightsTag, Tag, Text
@@ -32,6 +36,7 @@ class TagInline(admin.TabularInline):
 
 
 class PartnerAdmin(admin.ModelAdmin):
+    form = PartnerForm
 
     # Methods
     # ==
@@ -203,7 +208,7 @@ class TagAdmin(admin.ModelAdmin):
 
 
 class TextAdmin(admin.ModelAdmin):
-    pass
+    form = TextForm
 
 
 admin.site.register(Partner, PartnerAdmin)

--- a/cms/forms.py
+++ b/cms/forms.py
@@ -1,0 +1,35 @@
+from django import forms
+from cms.models import (
+    Partner,
+    Text,
+)
+
+
+class PartnerForm(forms.ModelForm):
+    class Meta:
+        model = Partner
+        fields = '__all__'
+
+    def clean_logo(self):
+        data = self.cleaned_data['logo']
+        if 'https://' not in data:
+            raise forms.ValidationError("Please only use https:// images.")
+        return data
+
+
+class TextForm(forms.ModelForm):
+    class Meta:
+        model = Text
+        fields = '__all__'
+
+    def clean_image_url(self):
+        data = self.cleaned_data['image_url']
+        if 'https://' not in data:
+            raise forms.ValidationError("Please only use https:// images.")
+        return data
+
+    def clean_video_url(self):
+        data = self.cleaned_data['video_url']
+        if 'https://' not in data:
+            raise forms.ValidationError("Please only use https:// links.")
+        return data


### PR DESCRIPTION
Block saving of asset fields on forms for Partner and Text objects, if they are not an https location.


## QA

- `./run`
- Go to http://localhost:8003/admin
- Try to save a new Partner and new Text with http assets. It should refuse!
