### PR TITLE
Roll back to an older version of global.js to stop JS errors.

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -28,7 +28,7 @@
 {% block footer_extra %}
     <script src="//assets.ubuntu.com/sites/ubuntu/latest/u/js/plugins/yui-min.js"></script>
     <script src="//assets.ubuntu.com/sites/ubuntu/latest/u/js/core.js"></script>
-    <script src="//assets.ubuntu.com/sites/ubuntu/latest/u/js/global.js"></script>
+    <script src="//assets.ubuntu.com/v1/bdd03093-global.js"></script>
     <script src="//assets.ubuntu.com/sites/ubuntu/latest/u/js/scratch.js"></script>
     <script src="//assets.ubuntu.com/sites/ubuntu/latest/u/js/plugins/respond.min.js"></script>
 {% endblock %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -121,7 +121,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script>
 <script src="//assets.ubuntu.com/sites/guidelines/js/responsive/core.js"></script>
 <script src="{{ STATIC_URL }}js/scratch.js"></script>
-<script src="//assets.ubuntu.com/sites/ubuntu/latest/u/js/global.js"></script>
+<script src="//assets.ubuntu.com/v1/bdd03093-global.js"></script>
 <script src="{{ STATIC_URL }}js/plugins/respond.min.js"></script>
 
 {% block footer_extra %}{% endblock %}


### PR DESCRIPTION
## Done

Fixed the global.js to a previous version to stop errors.

## QA

- `./run`
- See that there are no JS errors when navigating the pages of the site.