### PR TITLE
Remove unused wsgiref from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,4 @@ django-yaml-redirects==0.5.3
 django-markdown-deux==1.0.5
 django-template-finder-view==0.2
 django-openid-auth==0.14
-wsgiref==0.1.2; python_version < '3.0'
 whitenoise==3.3.0
-


### PR DESCRIPTION
Removing unused dependency. It does not appear to be references in the code and is causing issues with older pip versions.

## QA

Ensure the site runs and you can't find references to wsgiref in code.