### PR TITLE
Do not specify python3 in manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 import os
 import sys
 


### PR DESCRIPTION
This is currently causing an error on staging which is running python.
As soon as we update servers

## QA
./run should work correctly