### PR TITLE
Update preserialize for Django 1.10+ support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ canonicalwebteam.versioned-static==1.0.1
 Django==1.11.1
 Werkzeug==0.9.4
 django-extensions==1.7.9
-django-preserialize==1.1.0
+django-preserialize==1.2.1
 psycopg2==2.7.1
 dj-database-url==0.4.2
 python-openid==2.2.5


### PR DESCRIPTION
Update dependency which was using a removed funciton in Django 1.10

## QA
- `./run` should run correctly
- `/partners.json` should display content with no errors

Fix is deployed here and was erroring previously: https://partners.staging.ubuntu.com/partners.json