### PR TITLE
Update for featured filter to iterate as dict()

### DIFF
--- a/cms/views.py
+++ b/cms/views.py
@@ -268,13 +268,22 @@ def filter_partners(request, partners):
 
     try:
         query_list = Q()
-        for query, value in request.GET.iterlists():
+        for query, value in dict(request.GET).items():
             if query in filter_whitelist:
                 if len(value) > 1:
                     for listed_value in value:
+                        if listed_value.lower() == 'true':
+                            listed_value = True
+                        elif listed_value.lower() == 'false':
+                            listed_value = False
                         query_list = query_list | Q(**{query: listed_value})
                 else:
-                    partners = partners.filter(Q(**{query: value[0]}))
+                    listed_value = value[0]
+                    if listed_value.lower() == 'true':
+                        listed_value = True
+                    elif listed_value.lower() == 'false':
+                        listed_value = False
+                    partners = partners.filter(Q(**{query: listed_value}))
 
         distinct_partners = list(partners.filter(query_list).order_by(
             '-always_featured', '?'


### PR DESCRIPTION
Fix for featured feed causing an error. There has been an API change from Django upgrading.

Example error:
```
File "/home/will/dev/src/partners.ubuntu.com/cms/views.py" in __call__
  250.             response = self.f(*args, **kwargs)
File "/home/will/dev/src/partners.ubuntu.com/cms/views.py" in partners_json_view
  304.             get_grouped_random_partners()
File "/home/will/dev/src/partners.ubuntu.com/cms/views.py" in filter_partners
  294.         raise e
File "/home/will/dev/src/partners.ubuntu.com/cms/views.py" in filter_partners
  271.         for query, value in request.GET.iterlists():

Exception Type: AttributeError at /partners.json
Exception Value: 'QueryDict' object has no attribute 'iterlists'
```

## Done

- Convert use of QueryDict (request.GET) to a Dict
- Convert strings of true of false to bool

## QA

- ./run
- Ensure no error at http://0.0.0.0:8003/partners.json?programme=certified-public-cloud&featured=true