### PR TITLE
140: Fix redirect on report a bug link

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -40,11 +40,16 @@
 		<p class="twelve-col">&copy; {% now "Y" %} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
 		<ul class="inline clear">
 			<li><a href="https://www.ubuntu.com/legal">Legal information</a></li>
-			<li><a href="https://bugs.launchpad.net/ubuntu-partner-website">Report a bug on this site</a></li>
+			<li><a href="https://github.com/canonical-websites/partners.ubuntu.com/issues/new" id="report-a-bug">Report a bug on this site</a></li>
 		</ul>
 		<span class="accessibility-aid"><a href="#">Got to the top of the page</a></span>
 	</div>
 </div>
+<script>
+  /* Add the page to the report a bug link */
+  var bugLink = document.querySelector('#report-a-bug');
+  bugLink.href += '?body=%0a%0a%0a---%0a*Reported%20from:%20' + location.href + '*';
+</script>
 </footer>
 </div>
 {% endblock footer %}


### PR DESCRIPTION
## Done

- Updated 'Report a bug' link to redirect to a new GitHub issue instead of on Launchpad

## QA

- Pull code, run `./run` and navigate to http://0.0.0.0:8003/
- Click the 'Report a bug on this site' link at the bottom of the footer
- Check that it redirects to a new issue on the partners.ubuntu.com repo, with a footer saying which page the issue was reported from

## Issue / Card

Fixes #140 
