### PR TITLE
Add redirect for /hp to /hewlett-packard-enterprise

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,3 +1,4 @@
 programmes/reseller/?: /programmes/channel
 amazon-web-services-llc/?: /aws
 programmes/phone/?: /
+hp/?: /hewlett-packard-enterprise


### PR DESCRIPTION
## Done

- Added redirec for /hp to /hewlett-packard-enterprise

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8003/hp
- See that you get redirected to http://0.0.0.0:8003/hewlett-packard-enterprise

## Issue / Card

Fixes #146

