### PR TITLE
Update the contact us interested in field options

### DIFF
--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -74,25 +74,26 @@
 <fieldset class="fieldset-3">
     <h3>Partner programme</h3>
     <ul class="no-bullets">
-        <li  class="mktFormReq mktField">
-<label for="partner_tier__c" class="mktoLabel " >Applying for: <span>*</span></label>
-<select required  id="partner_tier__c" name="partner_tier__c" title="" class="mktoField  mktoRequired" ><option value="">Select...</option><option value="OEM">OEM</option><option value="ODM">ODM</option><option value="ISV">Software (ISV)</option><option value="IHV">Hardware (IHV)</option><option value="SI">Channel Partner / SI</option><option value="Cloud">Ubuntu OpenStack Partner</option><option value="UOIL">Ubuntu OpenStack interoperability lab (UOIL)</option><option value="CPP">Charm partner programme</option><option value="CPC">Certified Public Cloud</option><option value="Things">Internet of Things</option><option value="Other">Other</option></select>
+        <li class="mktFormReq mktField">
+            <label for="partner_tier__c" class="mktoLabel " >Interested in: <span>*</span></label>
+            <select required  id="partner_tier__c" name="partner_tier__c" title="" class="mktoField  mktoRequired" >
+            <option value="">Select...</option><option value="CPC">Certified Public Cloud</option><option value="Channel/SI/Reseller">Channel/SI/Reseller</option><option value="IHV">IHV - Integrated Hardware Vendor</option><option value="ISV">ISV - Integrated Software Vendor</option><option value="Things">Internet of Things</option><option value="OEM">OEM</option><option value="Other">Other</option></select>
+        </li>
+        <li class="mktFormReq mktField">
+            <label for="Comments_from_lead__c" class="mktoLabel " >Please tell us more about the opportunity you see in partnering with Canonical: <span>*</span></label>
+            <textarea required  id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" title="" class="mktoField  mktoRequired" maxlength="2000" ></textarea>
         </li>
 
-        <li  class="mktFormReq mktField">
-<label for="Comments_from_lead__c" class="mktoLabel " >Please tell us more about the opportunity you see in partnering with Canonical: <span>*</span></label>
-<textarea required  id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" title="" class="mktoField  mktoRequired" maxlength="2000" ></textarea>
+        <li class="mktField">
+            <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox">
+            <label  class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I agree to receive information about Canonical’s products and services.</label>
         </li>
-
-    <li  class="mktField">
-        <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox">
-        <label  class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I agree to receive information about Canonical’s products and services.</label>
-    </li>
-    <li>In submitting this form, I confirm that I have read and agree to <a target="_blank" href="https://www.ubuntu.com/legal/dataprivacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a target="_blank" href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</li>
+        <li>
+            In submitting this form, I confirm that I have read and agree to <a target="_blank" href="https://www.ubuntu.com/legal/dataprivacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a target="_blank" href="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.
+        </li>
         <li  class="mktField">
-<button type="submit" class="mktoButton">Submit</button></span><input type="hidden" name="formid" class="mktoField " value="1260"><input type="hidden" name="lpId" class="mktoField " value="1558"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/become-a-partner.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
+            <button type="submit" class="mktoButton">Submit</button></span><input type="hidden" name="formid" class="mktoField " value="1260"><input type="hidden" name="lpId" class="mktoField " value="1558"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/become-a-partner.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
         </li>
-
     </ul>
 </fieldset>
 


### PR DESCRIPTION
## Done
Update the contact us interested in field options. Tidied up the tabbing a little too.

## QA
- Go to /contact-us
- Check that the Interested in options match the partners form:
![screenshot from 2018-06-27 14-33-49](https://user-images.githubusercontent.com/1413534/41977568-918af86a-7a17-11e8-83eb-01edf940183c.png)

## Issue / Card
Fixes https://github.com/canonical-websites/partners.ubuntu.com/issues/156
