### PR TITLE
159: Update IBM partners page

### DIFF
--- a/static/sass/_partners-card.scss
+++ b/static/sass/_partners-card.scss
@@ -1,0 +1,31 @@
+/* Remove after updating site to latest Vanilla */
+
+.p-card--partners {
+  background: #fff;
+  border: 1px solid #cdcdcd;
+  border-radius: 2px;
+  box-shadow: 0 1px 5px 1px rgba(17, 17, 17, 0.2);
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+
+  .p-card__title {
+    font-size: .875rem;
+    font-weight: 100;
+    margin-bottom: 0;
+    padding: .75rem 1rem;
+    text-transform: uppercase;
+  }
+
+  .p-card__thumbnail {
+    display: block;
+    margin: 0 auto 1rem auto;
+  }
+
+  .p-card__content {
+    border-top: 1px solid #cdcdcd;
+    flex-shrink: 0;
+    margin: 0 .5rem;
+    padding: 1rem .5rem 1.5rem .5rem;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -78,6 +78,7 @@
 -------------------------------------------------------------- */
 @import "core-constants";
 @import "core-mixins";
+@import "partners-card";
 
 // vendor
 @import '../global-nav/src/sass/main';

--- a/templates/partner.html
+++ b/templates/partner.html
@@ -47,9 +47,11 @@
             {% endif %}
                 <h2>{{ text.fields.header }}</h2>
                 {{ text.fields.body|markdown }}
-                {% if text.fields.read_more_link %}<p><a href="{{ text.fields.read_more_link }}" class="{% if text.fields.read_more_cta %}link-cta-ubuntu"{% else %}{% if text.fields.read_more_external %} external{% endif %}{% endif %}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} - {{ text.fields.header }} row link', 'eventValue' : undefined });">{% if text.fields.read_more_link_text %}{{text.fields.read_more_link_text}}{% else %}Read more{% endif %}{% if not text.fields.read_more_cta and not text.fields.read_more_external %}&nbsp;&rsaquo;{% endif %}</a></p>{% endif %}
+                {% if text.fields.read_more_link %}<p><a href="{{ text.fields.read_more_link }}" class="{% if text.fields.read_more_cta %}link-cta-ubuntu{% else %}{% if text.fields.read_more_external %} external{% endif %}{% endif %}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} - {{ text.fields.header }} row link', 'eventValue' : undefined });">{% if text.fields.read_more_link_text %}{{text.fields.read_more_link_text}}{% else %}Read more{% endif %}{% if not text.fields.read_more_cta and not text.fields.read_more_external %}&nbsp;&rsaquo;{% endif %}</a></p>{% endif %}
             </div>
             {% if forloop.counter|divisibleby:2 %}
+            {% elif text.fields.header == "Ubuntu for LinuxONE and IBM Z" %}
+                {% include "templates/_ibm-card.html" %}
             {% else %}
             <div class="last-col four-col align-center align-vertically">
                 {% if text.fields.image_url %}<img src="{{ text.fields.image_url }}" alt="" class="cms-text--image" />{% endif %}

--- a/templates/templates/_ibm-card.html
+++ b/templates/templates/_ibm-card.html
@@ -1,0 +1,13 @@
+
+<div class="four-col last-col">
+    <div class="p-card--partners">
+        <h3 class="p-card__title">Cloud and server news</h4>
+        <div class="p-card__content">
+            <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/32d396bf-LinuxONE-logo.png" alt="">
+            <a href="https://blog.ubuntu.com/2018/04/11/ubuntu-available-on-ibm-linuxone-rockhopper-ii">
+                <h3>Ubuntu available on IBM LinuxOne Rockhopper II&nbsp;&rsaquo;</h3>
+            </a>
+            <p>IBM and Canonical have ensured that Ubuntu is available on IBM Z and LinuxONE servers.</p>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Done

- Updated /ibm page with new card
- Updated CMS to remove insights tags (to remove empty "Further reading" headings)

## QA

- Check out this feature branch
- Run the site using the command `./run`
- Go to http://0.0.0.0:8003/admin and copy the IBM partner details from partners.ubuntu.com/admin
- Go to http://0.0.0.0:8003/ibm
- Check that there is a card that looks like the one [here](https://mongoose.ubuntu.com/openstack/managed)

## Issue / Card

Fixes #159 

## Screenshots

![0 0 0 0_8003_ibm](https://user-images.githubusercontent.com/25733845/43465597-941dc3ae-94d5-11e8-8444-37ff5f39af35.png)

