### PR TITLE
Add global nav, stock Vanilla navigation and first pass of homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   },
   "devDependencies": {
     "node-sass": "^4.5.3",
-    "sass-lint": "^1.10.2",
-    "vanilla-framework": "1.8.x"
+    "sass-lint": "^1.10.2"
   },
   "dependencies": {
-    "global-nav": "^0.2.3"
+    "global-nav": "^1.0.0",
+    "vanilla-framework": "1.8.0"
   }
 }

--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -17,10 +17,6 @@ var yuiOptions = {
 };
 
 YUI(yuiOptions).use('node', 'cookie', "event-resize", "transition", "event", function (Y) {
-  core.setupHtmlClass = function () {
-    Y.all('html').removeClass('no-js').addClass('yes-js');
-  }
-
   core.setupAccordion = function() {
     Y.all('.row-project li').each(function(node) {
       node.one('h3').append('<span></span>');
@@ -121,6 +117,4 @@ YUI(yuiOptions).use('node', 'cookie', "event-resize", "transition", "event", fun
 
   core.setupAccordion();
   core.cookiePolicy();
-  core.setupHtmlClass();
-
 });

--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -1,7 +1,7 @@
+if(!core){ var core = {}; }
 
-
-//Provides basic templating for strings: TODO: Find a home for this
-String.prototype.format = function() {
+//Provides basic templating for strings
+String.prototype.format = function () {
   var args = arguments;
   return this.replace(/{(\d+)}/g, function(match, number) {
     return typeof args[number] != 'undefined'
@@ -16,172 +16,111 @@ var yuiOptions = {
   combine: true
 };
 
-YUI(yuiOptions).use('node', 'cookie', "event-resize", "transition", "event", function(Y) {
+YUI(yuiOptions).use('node', 'cookie', "event-resize", "transition", "event", function (Y) {
+  core.setupHtmlClass = function () {
+    Y.all('html').removeClass('no-js').addClass('yes-js');
+  }
 
-core.setupHtmlClass = function() {
-  Y.all('html').removeClass('no-js').addClass('yes-js');
-}
-
-core.setupAccordion = function() {
-  Y.all('.row-project li').each(function(node) {
-    node.one('h3').append('<span></span>');
-    node.one('a').on('click',function(e) {
-      e.preventDefault();
-      this.toggleClass('active');
-      this.next('div').toggleClass('active');
-    });
-  });
-};
-
-core.cookiePolicy = function() {
-  function open() {
-    YUI(yuiOptions).use('node', function(Y) {
-      Y.one('body').prepend('<div class="cookie-policy"><div class="wrapper"><a href="?cp=close" class="link-cta">Close</a><p>We use cookies to improve your experience. By your continued use of this site you accept such use. To change your settings please <a href="/privacy-policy#cookies">see our policy</a>.</p></div></div>');
-      Y.one('footer.global .legal').addClass('has-cookie');
-      Y.one('.cookie-policy .link-cta').on('click',function(e){
+  core.setupAccordion = function() {
+    Y.all('.row-project li').each(function(node) {
+      node.one('h3').append('<span></span>');
+      node.one('a').on('click',function(e) {
         e.preventDefault();
-        close();
+        this.toggleClass('active');
+        this.next('div').toggleClass('active');
       });
     });
-  }
-  function close() {
-    YUI(yuiOptions).use('node', function(Y) {
-      Y.one('.cookie-policy').setStyle('display','none');
-      Y.one('footer.global .legal').removeClass('has-cookie');
-      setCookie();
-    });
-  }
-  function setCookie() {
-    YUI(yuiOptions).use('cookie', function (Y) {
-      Y.Cookie.set("_cookies_accepted", "true", { expires: new Date("January 12, 2025") });
-    });
-  }
-  if(Y.Cookie.get("_cookies_accepted") != 'true'){
-    open();
-  }
-};
+  };
 
-core.rssLoader = {
-  "outputFeed" : function(el) {
-    var element = document.getElementById(el);
-    return function(result){
-      if (!result.error){
-        var output = '';
-        var thefeeds = result.feed.entries;
-        var spinner = document.getElementById('spinner');
-        if(spinner !== null){
-          spinner.style.display = 'none';
-        }
-        if(element.className.indexOf('with-total') != -1){
-          output += '<li>We currently have '+thefeeds.length+' vacancies';
-        }
-        console.log(thefeeds);
-        for (var i = 0; i < thefeeds.length; i++){
-          output += '<li><a href="{0}">{1} &rsaquo;</a></li>'.format(thefeeds[i].link, thefeeds[i].title);
-        }
-        element.innerHTML = element.innerHTML + output;
-        return output;
-      }
+  core.cookiePolicy = function() {
+    function open() {
+      YUI(yuiOptions).use('node', function(Y) {
+        Y.one('body').prepend('<div class="cookie-policy"><div class="wrapper"><a href="?cp=close" class="link-cta">Close</a><p>We use cookies to improve your experience. By your continued use of this site you accept such use. To change your settings please <a href="/privacy-policy#cookies">see our policy</a>.</p></div></div>');
+        Y.one('.cookie-policy .link-cta').on('click',function(e){
+          e.preventDefault();
+          close();
+        });
+      });
     }
-  },
-
-  "getFeed" : function(url, numItems, el){
-    var feedpointer = new google.feeds.Feed(url); //Google Feed API method
-    console.log(numItems);
-    if(numItems !== null){
-      feedpointer.setNumEntries(numItems); //Google Feed API method
-    }else{
-      feedpointer.setNumEntries(250); //Google Feed API method
+    function close() {
+      YUI(yuiOptions).use('node', function(Y) {
+        Y.one('.cookie-policy').setStyle('display','none');
+        setCookie();
+      });
     }
-    feedpointer.load(this.outputFeed(el)); //Google Feed API method
-  }
-};
-
-core.parallaxBackground = function() {
-  var body = Y.one('html');
-  if(window.devicePixelRatio < 1.5){
-    Y.on('scroll', function(e) {
-      body.setStyle('backgroundPosition', 'center ' + -window.scrollY * 0.5 + 'px');
-    });
-  }
-};
-
-core.homeAnimation = function() {
-  if(Y.one('body').hasClass('home')){
-    var anim = Y.one('.animation');
-    if(anim !== null) {
-      anim.addClass('run');
+    function setCookie() {
+      YUI(yuiOptions).use('cookie', function (Y) {
+        Y.Cookie.set("_cookies_accepted", "true", { expires: new Date("January 12, 2025") });
+      });
     }
-  }
-};
+    if(Y.Cookie.get("_cookies_accepted") != 'true'){
+      open();
+    }
+  };
 
-core.svgFallback = function() {
-  if (!Modernizr.svg || !Modernizr.backgroundsize) {
-    Y.all("img[src$='.svg']").each(function(node) {
-      node.setAttribute("src", node.getAttribute('src').toString().match(/.*\/(.+?)\./)[0]+'png');
-    });
-  }
-};
-
-core.autoLastItem = function() {
-  var y = 0,
-    lastNode = null;
-  setTimeout(function(){
-    Y.all('.list-auto').each(function(node) {
-      node.all('li').each(function(node) {
-        y = node.getXY()[1];
-        if(lastNode) {
-          ly = lastNode.getXY()[1];
-          if(y > ly + 50) { //Added +50 to stop differing-height images breaking this
-            lastNode.addClass('last-item');
+  core.rssLoader = {
+    "outputFeed" : function(el) {
+      var element = document.getElementById(el);
+      return function(result){
+        if (!result.error){
+          var output = '';
+          var thefeeds = result.feed.entries;
+          var spinner = document.getElementById('spinner');
+          if(spinner !== null){
+            spinner.style.display = 'none';
           }
+          if(element.className.indexOf('with-total') != -1){
+            output += '<li>We currently have '+thefeeds.length+' vacancies';
+          }
+          for (var i = 0; i < thefeeds.length; i++){
+            output += '<li><a href="{0}">{1} &rsaquo;</a></li>'.format(thefeeds[i].link, thefeeds[i].title);
+          }
+          element.innerHTML = element.innerHTML + output;
+          return output;
         }
-        lastNode = node;
-      });
-      if(lastNode){
-        lastNode.addClass('last-item');
-        y = 0;
-        lastNode = null;
+      }
+    },
+
+    "getFeed" : function(url, numItems, el){
+      var feedpointer = new google.feeds.Feed(url); //Google Feed API method
+      if(numItems !== null){
+        feedpointer.setNumEntries(numItems); //Google Feed API method
+      }else{
+        feedpointer.setNumEntries(250); //Google Feed API method
+      }
+      feedpointer.load(this.outputFeed(el)); //Google Feed API method
+    }
+  };
+
+  loadRSSFeed = function(id, tag, limit, url, title) {
+    var feedURL = "https://insights.ubuntu.com/feed/";
+    if (tag) {
+      feedURL += "?tag=" + tag;
+    }
+
+    if (limit) {
+      var feedLimit = limit | 5;
+    }
+    $.getFeed({
+      url: feedURL,
+      success: function(feed) {
+        var html = "<ul class='list'>";
+        for(var i = 0; i < feed.items.length && i < feedLimit; i++) {
+          var item = feed.items[i];
+          html += "<li><a href='" + item.link + "'>" + item.title + "&nbsp;&rsaquo;</a></li>";
+        }
+        html += "</ul>";
+        if ($('#' + id)) {
+          $('#' + id).append(html);
+        }
+      }, failure: function () {
+
       }
     });
-  }, 1000);
-};
-
-loadRSSFeed = function(id, tag, limit, url, title) {
-  var feedURL = "https://insights.ubuntu.com/feed/";
-  if (tag) {
-    feedURL += "?tag=" + tag;
   }
 
-  if (limit) {
-    var feedLimit = limit;
-  } else {
-    var feedLimit = 5;
-  }
-  $.getFeed({
-    url: feedURL,
-    success: function(feed) {
-      var html = "<ul class='list'>";
-      for(var i = 0; i < feed.items.length && i < feedLimit; i++) {
-        var item = feed.items[i];
-        html += "<li><a href='" + item.link + "'>" + item.title + "&nbsp;&rsaquo;</a></li>";
-      }
-      html += "</ul>";
-      if ($('#' + id)) {
-        $('#' + id).append(html);
-      }
-    }, failure: function () {
-
-    }
-  });
-}
-
-core.setupAccordion();
-core.cookiePolicy();
-core.setupHtmlClass();
-core.parallaxBackground();
-core.homeAnimation();
-core.svgFallback();
-core.autoLastItem();
+  core.setupAccordion();
+  core.cookiePolicy();
+  core.setupHtmlClass();
 
 });

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1,3 +1,18 @@
 @charset "UTF-8";
 
 @import 'vanilla-framework/scss/build';
+
+// XXX: KW-2018-08-16 - Fix for broken centre alignment with max-width elements
+// Can be removed when this is resolved in Vanilla:
+// https://github.com/vanilla-framework/vanilla-framework/issues/1794
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  &.u-align--center {
+    max-width: none;
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,95 +7,91 @@
 {% block extra_body_class %}home full-width{% endblock %}
 
 {% block content %}
-<section class="row row-hero strip no-border">
-    <div class="strip-inner-wrapper">
-        <div class="six-col">
-            <h1>Ubuntu partners</h1>
-            <p>At Canonical, we provide the services our partners need to ensure their hardware and software works optimally with the Ubuntu platform. This means working with technology leaders large and small, to provide the software, services, support and certification they need to complement their core competencies. For technology customers, this has created a thriving market of suppliers with Ubuntu expertise.</p>
-            <p><a href="/programmes">Learn more about our partner programmes&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="partners-image-container">
-            <div class="partners-hero-ubuntu"></div>
 
-            <div class="partners-hero-desktop"></div>
-            <div class="partners-hero-line-1"></div>
-
-            <div class="partners-hero-phone"></div>
-            <div class="partners-hero-line-2"></div>
-
-            <div class="partners-hero-tablet"></div>
-            <div class="partners-hero-line-3"></div>
-
-            <div class="partners-hero-server"></div>
-            <div class="partners-hero-line-4"></div>
-
-            <div class="partners-hero-cloud"></div>
-            <div class="partners-hero-line-5"></div>
-        </div>
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+        <h1>Ubuntu partners</h1>
+        <p>At Canonical, we provide the services our partners need to ensure their hardware and software works optimally with the Ubuntu platform. This means working with technology leaders large and small, to provide the software, services, support and certification they need to complement their core competencies. For technology customers, this has created a thriving market of suppliers with Ubuntu expertise.</p>
+        <p><a href="/programmes">Learn more about our partner programmes&nbsp;&rsaquo;</a></p>
     </div>
-</section>
+    <div class="partners-image-container">
+        <div class="partners-hero-ubuntu"></div>
 
-<section class="row strip strip-light no-border strip-logos">
-    <div class="strip-inner-wrapper">
-        <div class="list-auto twelve-col">
-            <h3 class="caps-centered">A selection of Ubuntu partners</h3>
-            <ul class="inline-logos no-bullets">
-            {% for partner in alliance_partners %}
-                <li><img src="{{ partner.logo }}" alt="{{ partner.name }}" /></li>
-            {% endfor %}
-            </ul>
-        </div>
-        <div class="twelve-col">
-            <p class="align-center"><a href="/find-a-partner">Browse all Ubuntu partners&nbsp;&rsaquo;</a></p>
-        </div>
+        <div class="partners-hero-desktop"></div>
+        <div class="partners-hero-line-1"></div>
+
+        <div class="partners-hero-phone"></div>
+        <div class="partners-hero-line-2"></div>
+
+        <div class="partners-hero-tablet"></div>
+        <div class="partners-hero-line-3"></div>
+
+        <div class="partners-hero-server"></div>
+        <div class="partners-hero-line-4"></div>
+
+        <div class="partners-hero-cloud"></div>
+        <div class="partners-hero-line-5"></div>
     </div>
+  </div>
 </section>
 
-<section class="row strip no-border">
-    <div class="strip-inner-wrapper equal-height">
-        <div class="six-col">
-            <h2>World leaders in the cloud</h2>
-            <p>We partner with a wide range of cloud vendors, offering engineering assistance, support and ongoing <a href="/programmes/openstack">quality assurance</a> to the ecosystem that is fast developing around Ubuntu and OpenStack. As a result, Ubuntu is the now world&rsquo;s most popular OS for OpenStack, with over 60% of deployments worldwide. Meanwhile, the <a href="/programmes/public-cloud">Certified Public Cloud</a> programme, offers optimised Ubuntu images for users of the world&rsquo;s top public clouds. Two levels of partnership &mdash; Premier and Certified &mdash; give partners the flexibility to choose a level of involvement that best suits their needs.</p>
-        </div>
-        <div class="six-col last-col align-center align-vertically">
-            <img src="{{ STATIC_URL }}img/juju-window-scaled.png" alt="Juju" />
-        </div>
-    </div><!-- /.strip-inner-wrapper -->
-</section>
-
-<section class="row strip no-border">
-    <div class="strip-inner-wrapper equal-height">
-        <div class="five-col align-center align-vertically">
-            <img src="{{ ASSET_SERVER_URL }}8d5f669e-DARWIN_2.png" alt="IoT robot" />
-        </div>
-        <div class="seven-col last-col">
-            <h2>Driving innovation in IoT and on PCs</h2>
-            <p>Canonical partners with <a href="/programmes/iot">IOT hardware and software vendors</a> providing product planning, integration, development and long term support. Our partners are active across many verticals: industrial, networking, home gateways, automotive, robotics and  digital signage. Together we’re redefining the world of IoT with secure, manageable, edge software from autonomous vehicles to preventive maintenance.</p>
-            <p>Thanks to Canonical's <a href="/programmes/hardware">OEM</a> and <a href="/programmes/retail">retail</a> partners, Ubuntu has been available pre-installed on consumer, desktop and industrial PCs all over the world, for several years. These PCs are developer’s preferred Linux development environment to create tomorrow’s cloud services and IoT devices.</p>
-        </div>
-    </div><!-- /.strip-inner-wrapper -->
-</section>
-
-<section class="row strip strip-light no-border">
-    <div class="strip-inner-wrapper row-image-centered">
-        <div class="eight-col">
-            <h2>Ubuntu is backed by Canonical</h2>
-            <p>Canonical is a software development and technology services company with staff in more than 30 countries around the world. Created alongside Ubuntu in 2004, it supports the platform’s development in many ways, from assisting with design and development to certification and the management of partner programmes.</p>
-            <p>We help you deliver your products without the cost and complexity associated with platform development. We provide training, support, QA and hands-on engineering expertise when you need it. Not to mention the marketing benefits of formalising your relationship with Ubuntu.</p>
-            <p><a href="/partnering-with-us">Learn more about Ubuntu and Canonical&nbsp;&rsaquo;</a></p>
-        </div>
-        <span>
-            <img class="priority-0" width="200" height="200" alt="Canonical Logo" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg">
-        </span>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-12">
+        <h3 class="p-muted-heading u-align--center">A selection of Ubuntu partners</h3>
+        <ul class="p-inline-images">
+        {% for partner in alliance_partners %}
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}">
+          </li>
+        {% endfor %}
+        </ul>
+        <p class="u-align--center u-vertically-spaced"><a href="/find-a-partner">Browse all Ubuntu partners&nbsp;&rsaquo;</a></p>
     </div>
+  </div>
 </section>
 
-<section class="row strip no-border">
-    <div class="strip-inner-wrapper">
-        {% include "templates/_contextual-footer.html" with strip=True %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+        <h2>World leaders in the cloud</h2>
+        <p>We partner with a wide range of cloud vendors, offering engineering assistance, support and ongoing <a href="/programmes/openstack">quality assurance</a> to the ecosystem that is fast developing around Ubuntu and OpenStack. As a result, Ubuntu is the now world&rsquo;s most popular OS for OpenStack, with over 60% of deployments worldwide. Meanwhile, the <a href="/programmes/public-cloud">Certified Public Cloud</a> programme, offers optimised Ubuntu images for users of the world&rsquo;s top public clouds. Two levels of partnership &mdash; Premier and Certified &mdash; give partners the flexibility to choose a level of involvement that best suits their needs.</p>
     </div>
+    <div class="col-6">
+        <img src="{{ STATIC_URL }}img/juju-window-scaled.png" alt="Juju" />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-5">
+        <img src="{{ ASSET_SERVER_URL }}8d5f669e-DARWIN_2.png" alt="IoT robot" />
+    </div>
+    <div class="col-7">
+        <h2>Driving innovation in IoT and on PCs</h2>
+        <p>Canonical partners with <a href="/programmes/iot">IOT hardware and software vendors</a> providing product planning, integration, development and long term support. Our partners are active across many verticals: industrial, networking, home gateways, automotive, robotics and  digital signage. Together we’re redefining the world of IoT with secure, manageable, edge software from autonomous vehicles to preventive maintenance.</p>
+        <p>Thanks to Canonical's <a href="/programmes/hardware">OEM</a> and <a href="/programmes/retail">retail</a> partners, Ubuntu has been available pre-installed on consumer, desktop and industrial PCs all over the world, for several years. These PCs are developer’s preferred Linux development environment to create tomorrow’s cloud services and IoT devices.</p>
+    </div>
+  </div>
 </section>
 
-<!-- This comment was updated on 2015-10-20 at 17:38 -->
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+        <h2>Ubuntu is backed by Canonical</h2>
+        <p>Canonical is a software development and technology services company with staff in more than 30 countries around the world. Created alongside Ubuntu in 2004, it supports the platform’s development in many ways, from assisting with design and development to certification and the management of partner programmes.</p>
+        <p>We help you deliver your products without the cost and complexity associated with platform development. We provide training, support, QA and hands-on engineering expertise when you need it. Not to mention the marketing benefits of formalising your relationship with Ubuntu.</p>
+        <p><a href="/partnering-with-us">Learn more about Ubuntu and Canonical&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4">
+        <img class="priority-0" width="200" height="200" alt="Canonical Logo" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    {% include "templates/_contextual-footer.html" with strip=True %}
+  </div>
+</section>
 
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,35 +8,15 @@
 
 {% block content %}
 
-<section class="p-strip--light">
+<section class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/775cc62b-vanilla-grad-background.png'); background-position: 75% 50%;">
   <div class="row">
-    <div class="col-6">
-        <h1>Ubuntu partners</h1>
-        <p>At Canonical, we provide the services our partners need to ensure their hardware and software works optimally with the Ubuntu platform. This means working with technology leaders large and small, to provide the software, services, support and certification they need to complement their core competencies. For technology customers, this has created a thriving market of suppliers with Ubuntu expertise.</p>
-        <p><a href="/programmes">Learn more about our partner programmes&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="partners-image-container">
-        <div class="partners-hero-ubuntu"></div>
-
-        <div class="partners-hero-desktop"></div>
-        <div class="partners-hero-line-1"></div>
-
-        <div class="partners-hero-phone"></div>
-        <div class="partners-hero-line-2"></div>
-
-        <div class="partners-hero-tablet"></div>
-        <div class="partners-hero-line-3"></div>
-
-        <div class="partners-hero-server"></div>
-        <div class="partners-hero-line-4"></div>
-
-        <div class="partners-hero-cloud"></div>
-        <div class="partners-hero-line-5"></div>
-    </div>
+    <h1>Ubuntu partners</h1>
+    <p>At Canonical, we provide the services our partners need to ensure their hardware and software works optimally with the Ubuntu platform. This means working with technology leaders large and small, to provide the software, services, support and certification they need to complement their core competencies. For technology customers, this has created a thriving market of suppliers with Ubuntu expertise.</p>
+    <p><a href="/programmes" class="p-link--inverted">Learn more about our partner programmes&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
         <h3 class="p-muted-heading u-align--center">A selection of Ubuntu partners</h3>
@@ -52,43 +32,45 @@
   </div>
 </section>
 
-<section class="p-strip--light">
-  <div class="row">
+<section class="p-strip">
+  <div class="row u-vertically-center">
     <div class="col-6">
-        <h2>World leaders in the cloud</h2>
+        <h2 class="p-heading--three">World leaders in the cloud</h2>
         <p>We partner with a wide range of cloud vendors, offering engineering assistance, support and ongoing <a href="/programmes/openstack">quality assurance</a> to the ecosystem that is fast developing around Ubuntu and OpenStack. As a result, Ubuntu is the now world&rsquo;s most popular OS for OpenStack, with over 60% of deployments worldwide. Meanwhile, the <a href="/programmes/public-cloud">Certified Public Cloud</a> programme, offers optimised Ubuntu images for users of the world&rsquo;s top public clouds. Two levels of partnership &mdash; Premier and Certified &mdash; give partners the flexibility to choose a level of involvement that best suits their needs.</p>
     </div>
-    <div class="col-6">
-        <img src="{{ STATIC_URL }}img/juju-window-scaled.png" alt="Juju" />
+    <div class="col-6 u-align--center">
+        <img src="{{ ASSET_SERVER_URL }}8149d09f-Service+View+-+zoom.png?h=332" alt="Juju" />
     </div>
   </div>
-  <div class="row">
-    <div class="col-5">
+</section>
+<section class="p-strip--light">
+  <div class="row u-vertically-center">
+    <div class="col-6">
         <img src="{{ ASSET_SERVER_URL }}8d5f669e-DARWIN_2.png" alt="IoT robot" />
     </div>
-    <div class="col-7">
-        <h2>Driving innovation in IoT and on PCs</h2>
+    <div class="col-6">
+        <h2 class="p-heading--three">Driving innovation in IoT and&nbsp;on&nbsp;PCs</h2>
         <p>Canonical partners with <a href="/programmes/iot">IOT hardware and software vendors</a> providing product planning, integration, development and long term support. Our partners are active across many verticals: industrial, networking, home gateways, automotive, robotics and  digital signage. Together we’re redefining the world of IoT with secure, manageable, edge software from autonomous vehicles to preventive maintenance.</p>
         <p>Thanks to Canonical's <a href="/programmes/hardware">OEM</a> and <a href="/programmes/retail">retail</a> partners, Ubuntu has been available pre-installed on consumer, desktop and industrial PCs all over the world, for several years. These PCs are developer’s preferred Linux development environment to create tomorrow’s cloud services and IoT devices.</p>
     </div>
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="row">
+<section class="p-strip is-bordered">
+  <div class="row u-vertically-center">
     <div class="col-8">
-        <h2>Ubuntu is backed by Canonical</h2>
+        <h2 class="p-heading--three">Ubuntu is backed by Canonical</h2>
         <p>Canonical is a software development and technology services company with staff in more than 30 countries around the world. Created alongside Ubuntu in 2004, it supports the platform’s development in many ways, from assisting with design and development to certification and the management of partner programmes.</p>
         <p>We help you deliver your products without the cost and complexity associated with platform development. We provide training, support, QA and hands-on engineering expertise when you need it. Not to mention the marketing benefits of formalising your relationship with Ubuntu.</p>
         <p><a href="/partnering-with-us">Learn more about Ubuntu and Canonical&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4">
-        <img class="priority-0" width="200" height="200" alt="Canonical Logo" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg">
+        <img class="u-hide--small" width="200" height="200" alt="Canonical Logo" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg">
     </div>
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip is-bordered">
   <div class="row">
     {% include "templates/_contextual-footer.html" with strip=True %}
   </div>

--- a/templates/templates/_contextual-footer.html
+++ b/templates/templates/_contextual-footer.html
@@ -1,94 +1,88 @@
-{% if not no_wrapper %}
-<div id="context-footer" class="{{ level_1 }}-context-footer no-border">
-    <hr />
-{% endif %}
-
-    <div class="twelve-col vertical-divider">
-    {% if level_1 == Null %}
-        <div class="feature-one six-col">
-            <h3>Partner programmes</h3>
-            <p>Interested in becoming an Ubuntu partner? Learn more about the benefits of working with Canonical.</p>
-            <p><a href="/programmes">See all partner programmes&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="feature-two six-col last-col">
-            <h3>Find a partner</h3>
-            <p>Looking for a supplier with Ubuntu expertise? or select from the complete list of our partners.</p>
-            <p><a href="/find-a-partner">Browse partners&nbsp;&rsaquo;</a></p>
-        </div>
-    {% elif level_1 == 'programmes' %}
-        {% if level_2 %}
-            <div class="feature-one six-col">
-                <h3>Become an Ubuntu partner</h3>
-                <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
-                <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
-            </div>
-        {% if level_2  == 'charm' %}
-            <div class="feature-two six-col last-col">
-                <h3>Further reading</h3>
-                <p><a class="external" href="https://insights.ubuntu.com/2016/02/21/charm-partner-programme/">Charm partner programme datasheet</a></p>
-            </div>
-        {% else %}
-        {% if level_2  == 'public-cloud' %}
-            <div class="feature-two six-col last-col">
-                <h3>Further reading</h3>
-                <ul class="no-bullets">
-                  <li><a class="external" href="https://insights.ubuntu.com/2016/10/07/ubuntu-certified-public-cloud-programme-2/">Ubuntu Certified Public Cloud programme datasheet</a></li>
-                  <li><a class="external" href="https://insights.ubuntu.com/2016/01/14/5-reasons-you-should-only-use-certified-images-on-the-public-cloud/">Certified Ubuntu Cloud Guest eBook</a></li>
-                </ul>
-            </div>
-        {% else %}
-            <div class="feature-two six-col last-col">
-                <h3>Partner programmes</h3>
-                <p>Do you offer different services to your customers? Learn more about other Ubuntu partner engagements.</p>
-                <p><a href="/programmes">Find the right programme for you&nbsp;&rsaquo;</a></p>
-            </div>
-        {% endif %}
-        {% endif %}
-        {% else %}
-            <div class="feature-one six-col">
-                <h3>Become an Ubuntu partner</h3>
-                <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
-                <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
-            </div>
-            <div class="feature-two six-col last-col">
-                <h3>Find a partner</h3>
-                <p>Looking for a supplier with Ubuntu expertise? or select from the complete list of our partners.</p>
-                <p><a href="/find-a-partner">Find a partner&nbsp;&rsaquo;</a></p>
-            </div>
-        {% endif %}
-    {% elif level_1 == 'find-a-partner' %}
-        <div class="feature-one six-col">
-            <h3>Become a partner</h3>
-            <p>Interested in becoming a partner? Talk to us today for more information about our programmes and certification.</p>
-            <p><a href="/contact-us">Get in touch&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="feature-two six-col last-col">
-            <h3>Get services and support</h3>
-            <p>Get on-site consulting services and training, direct from engineers involved in developing Ubuntu or subscribe to Ubuntu Advantage for systems management and support.</p>
-            <p><a href="https://www.ubuntu.com/support/plans-and-pricing" class="external">Learn more about Ubuntu Advantage</a></p>
-        </div>
-    {% elif level_1 == 'partnering-with-us' %}
-        <div class="feature-one six-col">
-            <h3>Become a partner</h3>
-            <p>If you’re in the industry and you&rsquo;re considering partnering with Canonical, please get in touch.</p>
-            <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="feature-two six-col last-col">
-            <h3>Partner programmes</h3>
-            <p>Canonical operates a range of partner programmes that help OEMs, ODMs, ISVs, cloud operators and mobile carriers maximise the revenue opportunities Ubuntu provides.</p>
-            <p><a href="/programmes">Find the right programme for you&nbsp;&rsaquo;</a></p>
-        </div>
-    {% else %}
-        <div class="feature-one six-col">
-            <h3>Become an Ubuntu partner</h3>
-            <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
-            <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="feature-two six-col last-col">
-            <h3>Partner programmes</h3>
-            <p>Do you offer different services to you customers? Learn more about other Ubuntu partner programmes.</p>
-            <p><a href="/programmes">Partner programmes&nbsp;&rsaquo;</a></p>
-        </div>
-    {% endif %}
-    </div>
-{% if not no_wrapper %}</div>{% endif %}
+<div class="row p-divider">
+  {% if level_1 == Null %}
+  <div class="feature-one col-6 p-divider__block">
+    <h3>Partner programmes</h3>
+    <p>Interested in becoming an Ubuntu partner? Learn more about the benefits of working with Canonical.</p>
+    <p><a href="/programmes">See all partner programmes&nbsp;&rsaquo;</a></p>
+  </div>
+  <div class="feature-two col-6 p-divider__block">
+    <h3>Find a partner</h3>
+    <p>Looking for a supplier with Ubuntu expertise? or select from the complete list of our partners.</p>
+    <p><a href="/find-a-partner">Browse partners&nbsp;&rsaquo;</a></p>
+  </div>
+  {% elif level_1 == 'programmes' %}
+  {% if level_2 %}
+  <div class="feature-one col-6 p-divider__block">
+    <h3>Become an Ubuntu partner</h3>
+    <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
+    <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
+  </div>
+  {% if level_2  == 'charm' %}
+  <div class="feature-two col-6 p-divider__block">
+    <h3>Further reading</h3>
+    <p><a class="external" href="https://insights.ubuntu.com/2016/02/21/charm-partner-programme/">Charm partner   programme datasheet</a></p>
+  </div>
+  {% else %}
+  {% if level_2  == 'public-cloud' %}
+  <div class="feature-two col-6 p-divider__block">
+    <h3>Further reading</h3>
+    <ul class="no-bullets">
+      <li><a class="external" href="https://insights.ubuntu.com/2016/10/07/ubuntu-certified-public-cloud-programme-2/">Ubuntu Certified Public Cloud programme datasheet</a></li>
+      <li><a class="external" href="https://insights.ubuntu.com/2016/01/14/5-reasons-you-should-only-use-certified-images-on-the-public-cloud/">Certified Ubuntu Cloud Guest eBook</a></li>
+    </ul>
+  </div>
+  {% else %}
+  <div class="feature-two col-6 p-divider__block">
+    <h3>Partner programmes</h3>
+    <p>Do you offer different services to your customers? Learn more about other Ubuntu partner engagements.</p>
+    <p><a href="/programmes">Find the right programme for you&nbsp;&rsaquo;</a></p>
+  </div>
+  {% endif %}
+  {% endif %}
+  {% else %}
+  <div class="feature-one col-6 p-divider__block">
+    <h3>Become an Ubuntu partner</h3>
+    <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
+    <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
+  </div>
+  <div class="feature-two col-6 p-divider__block">
+    <h3>Find a partner</h3>
+    <p>Looking for a supplier with Ubuntu expertise? or select from the complete list of our partners.</p>
+    <p><a href="/find-a-partner">Find a partner&nbsp;&rsaquo;</a></p>
+  </div>
+  {% endif %}
+  {% elif level_1 == 'find-a-partner' %}
+  <div class="feature-one col-6 p-divider__block">
+    <h3>Become a partner</h3>
+    <p>Interested in becoming a partner? Talk to us today for more information about our programmes and certification.</p>
+    <p><a href="/contact-us">Get in touch&nbsp;&rsaquo;</a></p>
+  </div>
+  <div class="feature-two col-6 p-divider__block">
+    <h3>Get services and support</h3>
+    <p>Get on-site consulting services and training, direct from engineers involved in developing Ubuntu or subscribe to Ubuntu Advantage for systems management and support.</p>
+    <p><a href="https://www.ubuntu.com/support/plans-and-pricing" class="external">Learn more about Ubuntu Advantage</a></p>
+  </div>
+  {% elif level_1 == 'partnering-with-us' %}
+  <div class="feature-one col-6 p-divider__block">
+    <h3>Become a partner</h3>
+    <p>If you’re in the industry and you&rsquo;re considering partnering with Canonical, please get in touch.</p>
+    <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
+  </div>
+  <div class="feature-two col-6 p-divider__block">
+    <h3>Partner programmes</h3>
+    <p>Canonical operates a range of partner programmes that help OEMs, ODMs, ISVs, cloud operators and mobile carriers maximise the revenue opportunities Ubuntu provides.</p>
+    <p><a href="/programmes">Find the right programme for you&nbsp;&rsaquo;</a></p>
+  </div>
+  {% else %}
+  <div class="feature-one col-6 p-divider__block">
+    <h3>Become an Ubuntu partner</h3>
+    <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
+    <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
+  </div>
+  <div class="feature-two col-6 p-divider__block">
+    <h3>Partner programmes</h3>
+    <p>Do you offer different services to you customers? Learn more about other Ubuntu partner programmes.</p>
+    <p><a href="/programmes">Partner programmes&nbsp;&rsaquo;</a></p>
+  </div>
+  {% endif %}
+</div>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -27,10 +27,6 @@
 <link rel="stylesheet" type="text/css" media="screen" href="{% versioned_static 'css/styles.css' %}" />
 <link rel="stylesheet" type="text/css" media="print" href="{% versioned_static 'css/core-print.css' %}" />
 
-<!-- modernizr -->
-<script src="{{ STATIC_URL }}js/plugins/modernizr.2.7.1.js"></script>
-<script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
-
 <link type="text/plain" rel="author" href="{% versioned_static 'files/humans.txt' %}" />
 
 {% block head_extra %}{% endblock %}
@@ -49,45 +45,54 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-K4K33T');</script>
 <!-- End Google Tag Manager -->
 
-<header class="banner global">
-{% block header_banner %}
-    <nav class="nav-primary nav-right">
-        <div class="logo">
-            <a class="logo-ubuntu" href="/">
-                <img width="106" height="25" alt="" src="https://assets.ubuntu.com/v1/c6679b95-logo-ubuntu-orange.svg">
-                <span>partners</span>
-            </a>
-        </div>
-        <ul>
-            <li class="accessibility-aid"><a accesskey="s" href="#main-content">Jump to content</a></li>
-            <li>
-                <a class="first{% if level_1 == 'programmes' %} active{% endif %}" href="/programmes">Programmes</a>
-                {% include "programmes/_nav_secondary.html" with promo="true" %}
-            </li>
-            <li><a{% if level_1 == 'find-a-partner' %} class="active"{% endif %} href="/find-a-partner">Find a partner</a></li>
-            <li><a{% if level_1 == 'partnering-with-us' %} class="active"{% endif %} href="/partnering-with-us">Partnering with us</a></li>
-            <li><a{% if level_1 == 'contact-us' %} class="active"{% endif %} href="/contact-us">Contact us</a></li>
-        </ul>
-        <a href="#canonlist" class="nav-toggle no-script">☰</a>
+<header id="navigation" class="p-navigation">
+  <div class="row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="/">
+          <img width="189" height="27" alt="Ubuntu" src="https://assets.ubuntu.com/v1/c6c41a4e-ubuntu-partners-logo.svg">
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+    <nav class="p-navigation__nav" role="menubar">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link{% if level_1 == 'programmes' %} is-selected{% endif %}">
+            <a role="menuitem" href="/programmes">Programmes</a>
+        </li>
+        <li class="p-navigation__link{% if level_1 == 'find-a-partner' %} is-selected{% endif %}">
+          <a role="menuitem" href="/find-a-partner">Find a partner</a>
+        </li>
+        <li class="p-navigation__link{% if level_1 == 'partnering-with-us' %} is-selected{% endif %}">
+          <a role="menuitem" href="/partnering-with-us">Partnering with us</a>
+        </li>
+        <li class="p-navigation__link{% if level_1 == 'contact-us' %} is-selected{% endif %}">
+          <a role="menuitem" href="/contact-us">Contact us</a>
+        </li>
+      </ul>
     </nav>
-{% endblock header_banner %}
+  </div>
 </header>
-<div class="wrapper u-no-margin--top">
-<div id="main-content" class="inner-wrapper">
-{% if level_1 %}
-{% block second_level_nav %}
-{% spaceless %}{% block second_level_nav_items %}{% endblock second_level_nav_items %}{% endspaceless %}
-{% endblock second_level_nav %}
-{% endif %}
 
-{% block header %}{% endblock %}
-{% block content_container %}
-{% block outer_content %}
-{% endblock outer_content %}
-{% endblock content_container %}
-</div><!-- /.inner-wrapper -->
+<div class="wrapper">
+  <div id="main-content" class="inner-wrapper">
+  {% if level_1 %}
+  {% block second_level_nav %}
+  {% spaceless %}{% block second_level_nav_items %}{% endblock second_level_nav_items %}{% endspaceless %}
+  {% endblock second_level_nav %}
+  {% endif %}
 
-</div><!-- /.wrapper -->
+  {% block header %}{% endblock %}
+  {% block content_container %}
+  {% block outer_content %}
+  {% endblock outer_content %}
+  {% endblock content_container %}
+  </div>
+</div>
 
 {% include "templates/footer.html" %}
 
@@ -100,17 +105,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script>
 
 <script src="https://assets.ubuntu.com/v1/40d25181-yui-combined.min.js"></script>
-<script>
-    if(!core){ var core = {}; }
-    core.globalPrepend = 'body';
-</script>
-<script src="https://assets.ubuntu.com/v1/8e7aa35a-core.js"></script>
 <script src="{{ STATIC_URL }}js/scratch.js"></script>
-<script src="{{ ASSET_SERVER_URL }}bdd03093-global.js"></script>
 <script src="{{ STATIC_URL }}js/plugins/respond.min.js"></script>
 
-<script src="{% versioned_static 'global-nav/build/js/global.js' %}"></script>
-<script>ubuntu.globalNav.setup();</script>
+<script src="{{ STATIC_URL }}global-nav/dist/index.js"></script>
+<script>canonicalGlobalNav.createNav({
+  maxWidth: '64.875rem'
+});</script>
+
 
 {% block footer_extra %}{% endblock %}
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -72,7 +72,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </nav>
 {% endblock header_banner %}
 </header>
-<div class="wrapper">
+<div class="wrapper u-no-margin--top">
 <div id="main-content" class="inner-wrapper">
 {% if level_1 %}
 {% block second_level_nav %}

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -1,55 +1,61 @@
 {% block footer %}
-<div class="footer-wrapper strip-light">
-<footer class="global clearfix">
-<nav>
-	<div class="row no-border">
-		<div id="canonlist" class="canonlist five-col">
-			<h2>Partners</h2>
-			<ul>
-				<li><a href="/">Home</a></li>
-				<li><a href="/programmes">Partner programmes</a></li>
-				<li><a href="/find-a-partner">Find a partner</a></li>
-				<li><a href="/partnering-with-us">Partnering with us</a></li>
-				<li><a href="/contact-us">Contact us</a></li>
-			</ul>
-		</div>
-		<div class="four-col">
-			<h2>Follow us</h2>
-			<ul class="list-social">
-				<li><a id="item-twitter" href="https://twitter.com/Ubuntu">@ubuntu on Twitter</a></li>
-				<li><a id="item-google" href="https://plus.google.com/+Ubuntu/posts">Ubuntu on Google+</a></li>
-				<li><a id="item-facebook" href="https://www.facebook.com/ubuntulinux?fref=ts">Ubuntu on Facebook</a></li>
-				<li><a id="item-canonical" href="http://blog.canonical.com">Canonical blog</a></li>
-			</ul>
-		</div>
-		<div id="additional-info" class="three-col last-col">
-			<h2>Find out more</h2>
-			<div>
-			<ul>
-				<li><a href="https://www.ubuntu.com/">Ubuntu</a></li>
-				<li><a href="https://www.ubuntu.com/support/plans-and-pricing">Ubuntu Advantage</a></li>
-				<li><a href="https://www.canonical.com/">Canonical</a></li>
-				<li><a href="https://insights.ubuntu.com/">Press and resources</a></li>
-			</ul>
-			</div>
-		</div>
-	</div>
-</nav>
-<div class="legal clearfix">
-	<div class="legal-inner">
-		<p class="twelve-col">&copy; {% now "Y" %} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-		<ul class="inline clear">
-			<li><a href="https://www.ubuntu.com/legal">Legal information</a></li>
-			<li><a href="https://github.com/canonical-websites/partners.ubuntu.com/issues/new" id="report-a-bug">Report a bug on this site</a></li>
-		</ul>
-		<span class="accessibility-aid"><a href="#">Got to the top of the page</a></span>
-	</div>
-</div>
-<script>
-  /* Add the page to the report a bug link */
-  var bugLink = document.querySelector('#report-a-bug');
-  bugLink.href += '?body=%0a%0a%0a---%0a*Reported%20from:%20' + location.href + '*';
-</script>
+<footer class="p-strip">
+  <nav>
+    <div class="row">
+      <div id="canonlist" class="col-5">
+        <h2 class="p-muted-heading p-heading--four">Partners</h2>
+        <ul class="p-list is-split">
+          <li class="p-list__item"><a href="/">Home</a></li>
+          <li class="p-list__item"><a href="/programmes">Partner programmes</a></li>
+          <li class="p-list__item"><a href="/find-a-partner">Find a partner</a></li>
+          <li class="p-list__item"><a href="/partnering-with-us">Partnering with us</a></li>
+          <li class="p-list__item"><a href="/contact-us">Contact us</a></li>
+        </ul>
+      </div>
+      <div class="col-4">
+        <h2 class="p-muted-heading p-heading--four">Follow us</h2>
+        <ul class="p-inline-list u-no-margin--top">
+          <li class="p-inline-list__item">
+            <a href="https://twitter.com/Ubuntu" title="@ubuntu on Twitter"><i class="p-icon--twitter">@ubuntu on Twitter</i></a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="https://plus.google.com/+Ubuntu/posts" title="Ubuntu on Google+"><i class="p-icon--google">Ubuntu on Google+</i></a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="https://www.facebook.com/ubuntulinux?fref=ts" title="Ubuntu on Facebook"><i class="p-icon--facebook">Ubuntu on Facebook</i></a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="http://blog.ubuntu.com" title="Ubuntu blog"><i class="p-icon--ubuntu">Ubuntu blog</i></a>
+          </li>
+        </ul>
+      </div>
+      <div id="additional-info" class="col-3">
+        <h2 class="p-muted-heading p-heading--four">Find out more</h2>
+        <div>
+        <ul class="p-list">
+          <li class="p-list__item"><a href="https://www.ubuntu.com/">Ubuntu</a></li>
+          <li class="p-list__item"><a href="https://www.ubuntu.com/support/plans-and-pricing">Ubuntu Advantage</a></li>
+          <li class="p-list__item"><a href="https://www.canonical.com/">Canonical</a></li>
+          <li class="p-list__item"><a href="https://insights.ubuntu.com/">Press and resources</a></li>
+        </ul>
+        </div>
+      </div>
+    </div>
+  </nav>
+  <div class="row">
+    <p style="max-width: none;">&copy; {% now "Y" %} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+    <nav class="p-footer__nav">
+      <ul class="p-footer__links">
+        <li class="p-footer__item"><a class="p-footer__link" href="https://www.ubuntu.com/legal">Legal information</a></li>
+        <li class="p-footer__item"><a class="p-footer__link" href="https://github.com/canonical-websites/partners.ubuntu.com/issues/new" id="report-a-bug">Report a bug on this site</a></li>
+      </ul>
+    </nav>
+    <span class="u-off-screen"><a href="#">Go to the top of the page</a></span>
+  </div>
+  <script>
+    /* Add the page to the report a bug link */
+    var bugLink = document.querySelector('#report-a-bug');
+    bugLink.href += '?body=%0a%0a%0a---%0a*Reported%20from:%20' + location.href + '*';
+  </script>
 </footer>
-</div>
 {% endblock footer %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -607,9 +607,9 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@~7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global-nav@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/global-nav/-/global-nav-0.2.3.tgz#8f61296bbf3803fdcff1540399c0fcc526f355ed"
+global-nav@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-nav/-/global-nav-1.0.0.tgz#6e5f6eaffb7f49014be1d405f0ff598ba85d4e5d"
 
 globals@^9.2.0:
   version "9.16.0"
@@ -1558,7 +1558,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.8.x:
+vanilla-framework@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.8.0.tgz#b5aacc3ce60a521b8de8f160cb505807aadc7869"
 


### PR DESCRIPTION
## Done

- Included global-nav from NPM
- Tidied up the markup and simplified the homepage
- Used stock Vanilla navigation
- Styled the footer removing custom styles
- Removed all unused files

## QA

- `./run`
- Check that the homepage renders and works well in-browser