### PR TITLE
Partnering with us

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -70,10 +70,6 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
-  <div class="row">
-    {% include "templates/_contextual-footer.html" with strip=True %}
-  </div>
-</section>
+{% include "templates/_contextual-footer.html" with strip=True %}
 
 {% endblock %}

--- a/templates/partnering-with-us/index.html
+++ b/templates/partnering-with-us/index.html
@@ -5,36 +5,35 @@
 {% block meta_keywords %}Canonical, Ubuntu, partner, partnership, program, programme, carrier, telco, mobile, network, phone, smartphone, tablet, cloud, OpenStack, public cloud, infrastructure, guest, image, server, ISV, software, hardware, enablement, certify, certified, certification, PC, laptop, desktop, Channel partners, VAR, channel, developer{% endblock %}
 
 {% block content %}
-<div class="row row-hero no-border">
-    <div class="six-col">
-        <h1>Partnering with Ubuntu and Canonical</h1>
-        <p>Ubuntu is an open source computing platform that is transforming the way millions of people and businesses use the client, the server and the cloud. Canonical is the company that supports it, providing strategic guidance and driving its adoption.</p>
-        <h2>How we work with our partners</h2>
-        <p>By formalising their partnership with Canonical, technology companies of all kinds &mdash; from hardware makers and ISVs to cloud providers and mobile carriers &mdash; benefit from significant opportunities to increase their revenues with Ubuntu.</p>
-        <p>We operate a range of partner programmes, from essential product certification to close collaboration, help with QA and long-term strategic alliances.</p>
-    </div>
-</div>
-<div class="row no-border strip-dark">
-    <div class="eight-col append-four">
-        <h2>What you get when you work with us</h2>
-        <p>Partnering with Canonical gives you:</p>
-    </div>
-    <div class="six-col">
-        <ul class="list-ubuntu">
-            <li>Certification of your products to ensure reliability and communicate this to your customers</li>
-            <li>Regular security and maintenance updates to any products that run Ubuntu</li>
-            <li>Access to engineers who develop Ubuntu, equipping you to use it as a platform for innovation in your market</li>
-            <li class="last-item"></li>
-        </ul>
-    </div>
-    <div class="six-col last-col">
-        <ul class="list-ubuntu">
-            <li>Custom engineering covering any device enablement or platform customisation your ideas require</li>
-            <li>Management of all third party licence fees and distribution agreements for content provided through Ubuntu</li>
-            <li class="last-item">Substantial marketing benefits &ndash; Ubuntu has more than 20 million client users and it is an established leader in the cloud. By working with us, you&rsquo;ll get to share in this growth.</li>
-        </ul>
-    </div>
-</div>
+<section class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/775cc62b-vanilla-grad-background.png'); background-position: 75% 50%;">
+  <div class="row">
+    <h1>Partnering with Ubuntu and Canonical</h1>
+    <p>Ubuntu is an open source computing platform that is transforming the way millions of people and businesses use the client, the server and the cloud. Canonical is the company that supports it, providing strategic guidance and driving its adoption.</p>
+  </div>
+</section>
+<section class="p-strip">
+  <div class="row">
+    <h2>How we work with our partners</h2>
+    <p>By formalising their partnership with Canonical, technology companies of all kinds &mdash; from hardware makers and ISVs to cloud providers and mobile carriers &mdash; benefit from significant opportunities to increase their revenues with Ubuntu.</p>
+    <p>We operate a range of partner programmes, from essential product certification to close collaboration, help with QA and long-term strategic alliances.</p>
+  </div>
+</section>
+<section class="p-strip--light">
+  <div class="row">
+    <h2>What you get when you work with us</h2>
+    <p>Partnering with Canonical gives you:</p>
+  </div>
+  <div class="row">
+    <ul class="p-list is-split">
+      <li class="p-list__item is-ticked">Certification of your products to ensure reliability and communicate this to your customers</li>
+      <li class="p-list__item is-ticked">Regular security and maintenance updates to any products that run Ubuntu</li>
+      <li class="p-list__item is-ticked">Access to engineers who develop Ubuntu, equipping you to use it as a platform for innovation in your market</li>
+      <li class="p-list__item is-ticked">Custom engineering covering any device enablement or platform customisation your ideas require</li>
+      <li class="p-list__item is-ticked">Management of all third party licence fees and distribution agreements for content provided through Ubuntu</li>
+      <li class="p-list__item is-ticked">Substantial marketing benefits &ndash; Ubuntu has more than 20 million client users and it is an established leader in the cloud. By working with us, you&rsquo;ll get to share in this growth.</li>
+    </ul>
+  </div>
+</section>
 
 {% include "templates/_contextual-footer.html" %}
 

--- a/templates/templates/_contextual-footer.html
+++ b/templates/templates/_contextual-footer.html
@@ -1,88 +1,92 @@
-<div class="row p-divider">
-  {% if level_1 == Null %}
-  <div class="feature-one col-6 p-divider__block">
-    <h3>Partner programmes</h3>
-    <p>Interested in becoming an Ubuntu partner? Learn more about the benefits of working with Canonical.</p>
-    <p><a href="/programmes">See all partner programmes&nbsp;&rsaquo;</a></p>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="row p-divider">
+      {% if level_1 == Null %}
+      <div class="feature-one col-6 p-divider__block">
+        <h3>Partner programmes</h3>
+        <p>Interested in becoming an Ubuntu partner? Learn more about the benefits of working with Canonical.</p>
+        <p><a href="/programmes">See all partner programmes&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="feature-two col-6 p-divider__block">
+        <h3>Find a partner</h3>
+        <p>Looking for a supplier with Ubuntu expertise? or select from the complete list of our partners.</p>
+        <p><a href="/find-a-partner">Browse partners&nbsp;&rsaquo;</a></p>
+      </div>
+      {% elif level_1 == 'programmes' %}
+      {% if level_2 %}
+      <div class="feature-one col-6 p-divider__block">
+        <h3>Become an Ubuntu partner</h3>
+        <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
+        <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
+      </div>
+      {% if level_2  == 'charm' %}
+      <div class="feature-two col-6 p-divider__block">
+        <h3>Further reading</h3>
+        <p><a class="external" href="https://insights.ubuntu.com/2016/02/21/charm-partner-programme/">Charm partner   programme datasheet</a></p>
+      </div>
+      {% else %}
+      {% if level_2  == 'public-cloud' %}
+      <div class="feature-two col-6 p-divider__block">
+        <h3>Further reading</h3>
+        <ul class="no-bullets">
+          <li><a class="external" href="https://insights.ubuntu.com/2016/10/07/ubuntu-certified-public-cloud-programme-2/">Ubuntu Certified Public Cloud programme datasheet</a></li>
+          <li><a class="external" href="https://insights.ubuntu.com/2016/01/14/5-reasons-you-should-only-use-certified-images-on-the-public-cloud/">Certified Ubuntu Cloud Guest eBook</a></li>
+        </ul>
+      </div>
+      {% else %}
+      <div class="feature-two col-6 p-divider__block">
+        <h3>Partner programmes</h3>
+        <p>Do you offer different services to your customers? Learn more about other Ubuntu partner engagements.</p>
+        <p><a href="/programmes">Find the right programme for you&nbsp;&rsaquo;</a></p>
+      </div>
+      {% endif %}
+      {% endif %}
+      {% else %}
+      <div class="feature-one col-6 p-divider__block">
+        <h3>Become an Ubuntu partner</h3>
+        <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
+        <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="feature-two col-6 p-divider__block">
+        <h3>Find a partner</h3>
+        <p>Looking for a supplier with Ubuntu expertise? or select from the complete list of our partners.</p>
+        <p><a href="/find-a-partner">Find a partner&nbsp;&rsaquo;</a></p>
+      </div>
+      {% endif %}
+      {% elif level_1 == 'find-a-partner' %}
+      <div class="feature-one col-6 p-divider__block">
+        <h3>Become a partner</h3>
+        <p>Interested in becoming a partner? Talk to us today for more information about our programmes and certification.</p>
+        <p><a href="/contact-us">Get in touch&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="feature-two col-6 p-divider__block">
+        <h3>Get services and support</h3>
+        <p>Get on-site consulting services and training, direct from engineers involved in developing Ubuntu or subscribe to Ubuntu Advantage for systems management and support.</p>
+        <p><a href="https://www.ubuntu.com/support/plans-and-pricing" class="external">Learn more about Ubuntu Advantage</a></p>
+      </div>
+      {% elif level_1 == 'partnering-with-us' %}
+      <div class="feature-one col-6 p-divider__block">
+        <h3>Become a partner</h3>
+        <p>If you’re in the industry and you&rsquo;re considering partnering with Canonical, please get in touch.</p>
+        <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="feature-two col-6 p-divider__block">
+        <h3>Partner programmes</h3>
+        <p>Canonical operates a range of partner programmes that help OEMs, ODMs, ISVs, cloud operators and mobile carriers maximise the revenue opportunities Ubuntu provides.</p>
+        <p><a href="/programmes">Find the right programme for you&nbsp;&rsaquo;</a></p>
+      </div>
+      {% else %}
+      <div class="feature-one col-6 p-divider__block">
+        <h3>Become an Ubuntu partner</h3>
+        <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
+        <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="feature-two col-6 p-divider__block">
+        <h3>Partner programmes</h3>
+        <p>Do you offer different services to you customers? Learn more about other Ubuntu partner programmes.</p>
+        <p><a href="/programmes">Partner programmes&nbsp;&rsaquo;</a></p>
+      </div>
+      {% endif %}
+    </div>
   </div>
-  <div class="feature-two col-6 p-divider__block">
-    <h3>Find a partner</h3>
-    <p>Looking for a supplier with Ubuntu expertise? or select from the complete list of our partners.</p>
-    <p><a href="/find-a-partner">Browse partners&nbsp;&rsaquo;</a></p>
-  </div>
-  {% elif level_1 == 'programmes' %}
-  {% if level_2 %}
-  <div class="feature-one col-6 p-divider__block">
-    <h3>Become an Ubuntu partner</h3>
-    <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
-    <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
-  </div>
-  {% if level_2  == 'charm' %}
-  <div class="feature-two col-6 p-divider__block">
-    <h3>Further reading</h3>
-    <p><a class="external" href="https://insights.ubuntu.com/2016/02/21/charm-partner-programme/">Charm partner   programme datasheet</a></p>
-  </div>
-  {% else %}
-  {% if level_2  == 'public-cloud' %}
-  <div class="feature-two col-6 p-divider__block">
-    <h3>Further reading</h3>
-    <ul class="no-bullets">
-      <li><a class="external" href="https://insights.ubuntu.com/2016/10/07/ubuntu-certified-public-cloud-programme-2/">Ubuntu Certified Public Cloud programme datasheet</a></li>
-      <li><a class="external" href="https://insights.ubuntu.com/2016/01/14/5-reasons-you-should-only-use-certified-images-on-the-public-cloud/">Certified Ubuntu Cloud Guest eBook</a></li>
-    </ul>
-  </div>
-  {% else %}
-  <div class="feature-two col-6 p-divider__block">
-    <h3>Partner programmes</h3>
-    <p>Do you offer different services to your customers? Learn more about other Ubuntu partner engagements.</p>
-    <p><a href="/programmes">Find the right programme for you&nbsp;&rsaquo;</a></p>
-  </div>
-  {% endif %}
-  {% endif %}
-  {% else %}
-  <div class="feature-one col-6 p-divider__block">
-    <h3>Become an Ubuntu partner</h3>
-    <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
-    <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
-  </div>
-  <div class="feature-two col-6 p-divider__block">
-    <h3>Find a partner</h3>
-    <p>Looking for a supplier with Ubuntu expertise? or select from the complete list of our partners.</p>
-    <p><a href="/find-a-partner">Find a partner&nbsp;&rsaquo;</a></p>
-  </div>
-  {% endif %}
-  {% elif level_1 == 'find-a-partner' %}
-  <div class="feature-one col-6 p-divider__block">
-    <h3>Become a partner</h3>
-    <p>Interested in becoming a partner? Talk to us today for more information about our programmes and certification.</p>
-    <p><a href="/contact-us">Get in touch&nbsp;&rsaquo;</a></p>
-  </div>
-  <div class="feature-two col-6 p-divider__block">
-    <h3>Get services and support</h3>
-    <p>Get on-site consulting services and training, direct from engineers involved in developing Ubuntu or subscribe to Ubuntu Advantage for systems management and support.</p>
-    <p><a href="https://www.ubuntu.com/support/plans-and-pricing" class="external">Learn more about Ubuntu Advantage</a></p>
-  </div>
-  {% elif level_1 == 'partnering-with-us' %}
-  <div class="feature-one col-6 p-divider__block">
-    <h3>Become a partner</h3>
-    <p>If you’re in the industry and you&rsquo;re considering partnering with Canonical, please get in touch.</p>
-    <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
-  </div>
-  <div class="feature-two col-6 p-divider__block">
-    <h3>Partner programmes</h3>
-    <p>Canonical operates a range of partner programmes that help OEMs, ODMs, ISVs, cloud operators and mobile carriers maximise the revenue opportunities Ubuntu provides.</p>
-    <p><a href="/programmes">Find the right programme for you&nbsp;&rsaquo;</a></p>
-  </div>
-  {% else %}
-  <div class="feature-one col-6 p-divider__block">
-    <h3>Become an Ubuntu partner</h3>
-    <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
-    <p><a href="/contact-us">Talk to us about becoming a partner&nbsp;&rsaquo;</a></p>
-  </div>
-  <div class="feature-two col-6 p-divider__block">
-    <h3>Partner programmes</h3>
-    <p>Do you offer different services to you customers? Learn more about other Ubuntu partner programmes.</p>
-    <p><a href="/programmes">Partner programmes&nbsp;&rsaquo;</a></p>
-  </div>
-  {% endif %}
-</div>
+</section>


### PR DESCRIPTION
## Done

Updated the partnering with us page and modified the contextual footer template to always have its own strip

## QA

- `./run`
- Go to /partnering-with-us