### PR TITLE
Fixes typo and stray word

### DIFF
--- a/templates/templates/_contextual-footer.html
+++ b/templates/templates/_contextual-footer.html
@@ -86,7 +86,7 @@
         </div>
         <div class="feature-two six-col last-col">
             <h3>Partner programmes</h3>
-            <p>Do you offer different services to you customers? Learn more about other Ubuntu partner programmes.</p>
+            <p>Do you offer different services to your customers? Learn more about Ubuntu partner programmes.</p>
             <p><a href="/programmes">Partner programmes&nbsp;&rsaquo;</a></p>
         </div>
     {% endif %}


### PR DESCRIPTION
## Done

On [the partners.ubuntu.com front page](https://partners.ubuntu.com/):

- Typo fix: “Do you offer different services to you customers?” to “Do you offer different services to your customers?”
- Stray word: “Learn more about other Ubuntu partner programmes” to “Learn more about Ubuntu partner programmes”. The front page doesn’t describe any particular programme, so “other” is incorrect.

## Not done

- The first sentence still doesn’t make sense. “Different services”? Different to what? Different to each other? Different to Canonical? Perhaps this was cargo-culted from the footer for individual programme pages, where it could mean “different to the service that’s helped by the programme you’re looking at right now”?

- Other pages on the site refer to “partner engagements” rather than “partner programmes”. But I would understand a “partner engagement” to be the relationship with an individual partner, rather than the programme as a whole.