### PR TITLE
Update public cloud page. Make ticks orange and tweak programmes markup.

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1,5 +1,7 @@
 @charset "UTF-8";
 
+$color-accent: #e95420;
+
 @import 'vanilla-framework/scss/build';
 
 // XXX: KW-2018-08-16 - Fix for broken centre alignment with max-width elements

--- a/templates/block/_logo-list.html
+++ b/templates/block/_logo-list.html
@@ -1,17 +1,17 @@
 {% if programme_partners %}
-<section class="row {% if extra_class %}{{ extra_class }}{% endif %}">
-    <div class="twelve-col">
-        <h3 class="caps-centered">A selection of our {{ name }}</h3>
-        <div class="list-auto twelve-col">
-            <ul class="inline-logos no-bullets">
-                {% for partner in programme_partners %}
-                    <li{% if forloop.last %} class='last-item'{% endif %}><img src="{{ partner.logo }}" alt="{{ partner.name }}" /></li>
-                {% endfor %}
-            </ul>
-        </div>
-        <div class="twelve-col">
-            <p class="align-center"><a href="/find-a-partner?{{ query }}">See all {{ name }}&nbsp;&rsaquo;</a></p>
-        </div>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+        <h3 class="p-muted-heading u-align--center">A selection of our {{ name }}</h3>
+        <ul class="p-inline-images">
+        {% for partner in programme_partners %}
+          <li class="p-inline-images__item">
+            <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.name }}">
+          </li>
+        {% endfor %}
+        </ul>
+        <p class="u-align--center u-vertically-spaced"><a href="/find-a-partner?{{ query }}">See all {{ name }}&nbsp;&rsaquo;</a></p>
     </div>
+  </div>
 </section>
 {% endif %}

--- a/templates/programmes/index.html
+++ b/templates/programmes/index.html
@@ -9,12 +9,14 @@
 {% endblock second_level_nav %}
 
 {% block content %}
-<section class="p-strip is-bordered">
+<section class="p-strip is-narrow">
   <div class="row">
     <div class="col-8">
       <p class="p-heading--four" style="max-width: none;">At Canonical, we run a range of partner programmes to help OEMs, ODMs, ISVs, IHVs, cloud operators and mobile carriers maximise the revenue opportunities Ubuntu provides.</p>
     </div>
   </div>
+</section>
+<section class="p-strip is-bordered u-no-padding--top">
   <div class="row">
     <ul class="p-matrix u-clearfix">
       <li class="p-matrix__item">

--- a/templates/programmes/public-cloud.html
+++ b/templates/programmes/public-cloud.html
@@ -4,55 +4,54 @@
 {% block meta_description %}Canonical has partnered with the very best cloud service providers to ensure that the best of Ubuntu - consistent, up-to-date, secure - is available to our joint user base.{% endblock %}
 {% block meta_keywords %}CPC, Certified Public Cloud, cloud ecosystem, cloud partners, cloud tools, Juju, Charm, orchestration, Ubuntu cloud, guest, Canonical{% endblock %}
 
-{% block second_level_nav_items %}
-    <nav role="navigation" class="nav-secondary clearfix">{% include "templates/_nav_breadcrumb.html" with section_title="Programmes" page_title="Certified Public cloud" %}</nav>
-{% endblock second_level_nav_items %}
+{% block second_level_nav %}
+  {% include "programmes/_nav_secondary.html" with section="public-cloud" %}
+{% endblock second_level_nav %}
 
 {% block content %}
-<div class="row row-hero no-border equal-height">
-    <div class="eight-col">
-        <h1 itemprop="name">Ubuntu Certified Public Cloud</h1>
-        <p>Ubuntu is enormously popular with providers delivering public cloud services today. Together with significant developer mindshare, a favourable licensing model and a policy of regular updates have made Ubuntu the number one platform for cloud guests, the world over.</p>
-        <p>If you operate a public cloud or you&rsquo;re considering launching one, the Ubuntu Certified Public Cloud programme lets you make certified, secure and up to date Ubuntu images available to your users, along with the opportunity to sell management, monitoring and commercial support from Canonical &mdash; all of which represent additional revenue opportunities. </p>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h1 class="p-heading--two">Ubuntu Certified Public Cloud</h1>
+      <p>Ubuntu is enormously popular with providers delivering public cloud services today. Together with significant developer mindshare, a favourable licensing model and a policy of regular updates have made Ubuntu the number one platform for cloud guests, the world over.</p>
+      <p>If you operate a public cloud or you&rsquo;re considering launching one, the Ubuntu Certified Public Cloud programme lets you make certified, secure and up to date Ubuntu images available to your users, along with the opportunity to sell management, monitoring and commercial support from Canonical &mdash; all of which represent additional revenue opportunities. </p>
     </div>
-    <div class="three-col last-col prepend-one align-center align-vertically">
-        <img class="priority-0" width="250" src="{{ STATIC_URL }}img/logos/certified_cloud_partner_hex.png" itemprop="image" alt="" />
+    <div class="col-4 u-hide--small">
+      <img width="213" src="{{ STATIC_URL }}img/logos/certified_cloud_partner_hex.png" itemprop="image" alt="" />
     </div>
-</div>
-<div class="row no-border strip-dark">
-    <div class="eight-col append-four">
-        <h2>What&rsquo;s included?</h2>
-        <p>There are many benefits for partners in the Ubuntu Certified Public Cloud programme:</p>
-    </div>
-    <div class="six-col">
-        <ul class="list-ubuntu">
-            <li>Certified Ubuntu cloud images, tuned and tested to your environment, ensure optimal performance</li>
-            <li>Regular and automated refresh of Ubuntu images for enhanced user experience and increased security</li>
-            <li class="last-item">Automated publication across all cloud availability zones for facilitated operations</li>
-        </ul>
-    </div>
-    <div class="six-col last-col">
-        <ul class="list-ubuntu">
-            <li>Being featured as a certified partner on the Ubuntu website, including the ability to use Ubuntu Public Cloud certification logos</li>
-            <li>Joint marketing opportunities, including revenue-sharing for services and management tools delivered under <a href="https://www.ubuntu.com/support/plans-and-pricing">Ubuntu Advantage</a></li>
-            <li class="last-item">Automated publication across all cloud availability zones for more efficient operations</li>
-        </ul>
-    </div>
-</div>
-
-<div class="row no-border">
-    <div class="eight-col">
-        <h2>Premier cloud partners</h2>
+  </div>
+</section>
+<section class="p-strip--light">
+  <div class="row">
+    <h2 class="p-heading--three">What&rsquo;s included?</h2>
+    <p>There are many benefits for partners in the Ubuntu Certified Public Cloud programme:</p>
+  </div>
+  <div class="row">
+    <ul class="p-list is-split">
+      <li class="p-list__item is-ticked">Certified Ubuntu cloud images, tuned and tested to your environment, ensure optimal performance</li>
+      <li class="p-list__item is-ticked">Automated publication across all cloud availability zones for facilitated operations</li>
+      <li class="p-list__item is-ticked">Being featured as a certified partner on the Ubuntu website, including the ability to use Ubuntu Public Cloud certification logos</li>
+      <li class="p-list__item is-ticked">Regular and automated refresh of Ubuntu images for enhanced user experience and increased security</li>
+      <li class="p-list__item is-ticked">Automated publication across all cloud availability zones for more efficient operations</li>
+      <li class="p-list__item is-ticked">Joint marketing opportunities, including revenue-sharing for services and management tools delivered under <a href="https://www.ubuntu.com/support/plans-and-pricing">Ubuntu Advantage</a></li>
+    </ul>
+  </div>
+</section>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+        <h2 class="p-heading--three">Premier cloud partners</h2>
         <p>We collaborate with our Premier Certified Public Cloud partners on numerous
         disruptive developments that are driving the cloud forward. They include
         <a href="https://jujucharms.com">Juju</a>, a groundbreaking application modelling
         tool that brings rapid deployment, scaling and integration of complex applications
         to any cloud, leading to ecosystem and workload growth for our partners.</p>
     </div>
-    <div class="prepend-one two-col last-col align-center">
+    <div class="col-4 u-hide--small">
         <img src="{{ STATIC_URL }}img/logos/logo-premiercloudpartner.svg" alt="">
     </div>
-</div>
+  </div>
+</section>
 
 {% include "block/_logo-list.html" with name="public cloud partners" query="programme=certified-public-cloud" extra_class="no-border" %}
 

--- a/templates/templates/_contextual-footer.html
+++ b/templates/templates/_contextual-footer.html
@@ -28,9 +28,9 @@
       {% if level_2  == 'public-cloud' %}
       <div class="feature-two col-6 p-divider__block">
         <h3>Further reading</h3>
-        <ul class="no-bullets">
-          <li><a class="external" href="https://insights.ubuntu.com/2016/10/07/ubuntu-certified-public-cloud-programme-2/">Ubuntu Certified Public Cloud programme datasheet</a></li>
-          <li><a class="external" href="https://insights.ubuntu.com/2016/01/14/5-reasons-you-should-only-use-certified-images-on-the-public-cloud/">Certified Ubuntu Cloud Guest eBook</a></li>
+        <ul class="p-list">
+          <li cloud="p-list__item"><a class="external" href="https://insights.ubuntu.com/2016/10/07/ubuntu-certified-public-cloud-programme-2/">Ubuntu Certified Public Cloud programme datasheet</a></li>
+          <li cloud="p-list__item"><a class="external" href="https://insights.ubuntu.com/2016/01/14/5-reasons-you-should-only-use-certified-images-on-the-public-cloud/">Certified Ubuntu Cloud Guest eBook</a></li>
         </ul>
       </div>
       {% else %}


### PR DESCRIPTION
## Done

- Updated markup for /programmes/public-cloud
- Made $color-accent Ubuntu orange
- Rebuilt the logo block
- Drive-by fix of the /programmes page spacing

## QA

- `./run`
- Go to /programmes/public-cloud - check that it renders well
- Go to /programmes - see that the spacing is a little better
