### PR TITLE
Update individual partner pages, simplify JS, add styling for specifi…

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -78,7 +78,7 @@ YUI(yuiOptions).use('node', 'cookie', "event-resize", "transition", "event", fun
   };
 
   loadRSSFeed = function(id, tag, limit, url, title) {
-    var feedURL = "https://insights.ubuntu.com/feed/";
+    var feedURL = "https://blog.ubuntu.com/feed/";
     if (tag) {
       feedURL += "?tag=" + tag;
     }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -72,7 +72,6 @@ p {
 
     @media only screen and (min-width : 768px) {
       background-image: url('https://assets.ubuntu.com/v1/518ad912-microsoft-build-conf.png?w=984');
-      min-height: 42vw
     }
 
     @media only screen and (min-width : 984px) {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -26,3 +26,93 @@ p {
 .p-media-object__image {
   min-width: 6rem;
 }
+
+// Partner page styles
+
+//Counteract negative margin of p-card__content
+.p-card__title.p-muted-heading {
+  margin-bottom: $sp-large;
+}
+
+.p-hero {
+  background-repeat: no-repeat;
+  background-size: cover;
+
+  &__text {
+    background-color: rgba(255, 255, 255, .85);
+    padding: $spv-intra $sph-inter;
+  }
+}
+
+
+// IBM page
+.ibm {
+  .p-hero {
+    background-image: url('https://assets.ubuntu.com/v1/3978eb15-cloud-lifestyle-with-screens.png?w=768');
+  }
+
+  @media only screen and (min-width : 768px) {
+    .p-hero {
+      background-image: url('https://assets.ubuntu.com/v1/3978eb15-cloud-lifestyle-with-screens.png?w=984');
+      min-height: 30vw;
+    }
+  }
+
+  @media only screen and (min-width : 984px) {
+    .p-hero {
+      background-image: url('https://assets.ubuntu.com/v1/3978eb15-cloud-lifestyle-with-screens.png?w=1500');
+    }
+  }
+}
+
+// Microsoft Page
+.microsoft {
+  .p-hero {
+    background-image: url('https://assets.ubuntu.com/v1/518ad912-microsoft-build-conf.png?w=768');
+
+    @media only screen and (min-width : 768px) {
+      background-image: url('https://assets.ubuntu.com/v1/518ad912-microsoft-build-conf.png?w=984');
+      min-height: 42vw
+    }
+
+    @media only screen and (min-width : 984px) {
+      background-image: url('https://assets.ubuntu.com/v1/518ad912-microsoft-build-conf.png?w=1500');
+    }
+  }
+
+  .azure-stack {
+    background-image: url('https://assets.ubuntu.com/v1/72be8745-azure-stack-hills.png');
+    background-position: 95% 100%;
+    background-repeat: no-repeat;
+    background-size: 100%;
+    padding-bottom: 220px;
+
+    @media only screen and (min-width : 768px) {
+      background-size: auto;
+      padding-bottom: 200px;
+    }
+
+    @media only screen and (min-width : 1400px) {
+      padding-bottom: 60px;
+    }
+  }
+}
+
+.amazon-web-services-llc,
+.amazon-web-services,
+.aws {
+  .p-hero {
+    background-image: url('https://assets.ubuntu.com/v1/89aed188-amazon-partners-hero-banner.jpg?w=768');
+    background-repeat: no-repeat;
+    background-size: cover;
+
+    @media only screen and (min-width : 768px) {
+        background-image: url('https://assets.ubuntu.com/v1/89aed188-amazon-partners-hero-banner.jpg?w=984');
+        min-height: 30vw;
+    }
+
+    @media only screen and (min-width : 984px) {
+        background-image: url('https://assets.ubuntu.com/v1/89aed188-amazon-partners-hero-banner.jpg');
+    }
+  }
+}

--- a/templates/partner.html
+++ b/templates/partner.html
@@ -39,7 +39,7 @@
 <section class="p-strip{% if forloop.counter|divisibleby:2 %}--light{% endif %} cms-text is-bordered{% if text.fields.html_class%} {{ text.fields.html_class }}{% endif %}">
   <div class="row u-vertically-center">
     {% if forloop.counter|divisibleby:2 %}
-    <div class="col-4 align-center align-vertically">
+    <div class="col-4 u-align--center">
       {% if text.fields.image_url %}<img src="{{ text.fields.image_url }}" alt="" class="cms-text--image" />{% endif %}
     </div>
     <div class="col-8">
@@ -78,7 +78,9 @@
 
     {% if text.fields.video_url %}
     <div class="col-6 u-align--center">
-      <iframe width="442" height="249" src="{{text.fields.video_url}}?rel=0&amp;wmode=opaque&amp;modestbranding=0" frameborder="0" allowfullscreen></iframe>
+      <div class="u-embedded-media">
+        <iframe width="442" height="249" src="{{text.fields.video_url}}?rel=0&amp;wmode=opaque&amp;modestbranding=0" frameborder="0" allowfullscreen></iframe>
+      </div>
     </div>
     {% endif %}
   </div>

--- a/templates/partner.html
+++ b/templates/partner.html
@@ -42,7 +42,7 @@
     <div class="col-4 align-center align-vertically">
       {% if text.fields.image_url %}<img src="{{ text.fields.image_url }}" alt="" class="cms-text--image" />{% endif %}
     </div>
-    <div class="col-8 last-col">
+    <div class="col-8">
     {% else %}
     <div class="col-8 cms-text--content">
     {% endif %}
@@ -93,10 +93,10 @@
 <section class="p-strip">
   <div class="row">
     {% for quote in partner.quotes %}
-    <div class="box six-col{% if forloop.counter|divisibleby:2 %} last-col{% endif %}">
-      <blockquote class="pull-quote">
-        <p><span>&ldquo;</span>{{ quote.fields.text }}<span>&rdquo;</span></p>
-        <p><cite>{{ quote.fields.attribution }}</cite></p>
+    <div class="col-6">
+      <blockquote class="p-pull-quote">
+        <p>{{ quote.fields.text }}</p>
+        <cite class="p-pull-quote__citation">{{ quote.fields.attribution }}</cite>
       </blockquote>
     </div>
     {% endfor %}
@@ -110,9 +110,9 @@
     {% if partner.links %}
     <div class="col-6">
       <h2>Links</h2>
-      <ul class="no-bullets">
+      <ul class="p-list">
         {% for link in partner.links %}
-        <li><a class="p-link--external" href="{{ link.fields.url }}"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} - {{ link.fields.text }} link', 'eventValue' : undefined });">{{ link.fields.text }}</a></li>
+        <li class="p-list__item"><a class="p-link--external" href="{{ link.fields.url }}"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} - {{ link.fields.text }} link', 'eventValue' : undefined });">{{ link.fields.text }}</a></li>
         {% endfor %}
       </ul>
     </div>

--- a/templates/partner.html
+++ b/templates/partner.html
@@ -48,7 +48,7 @@
     {% endif %}
       <h2>{{ text.fields.header }}</h2>
       {{ text.fields.body|markdown }}
-      {% if text.fields.read_more_link %}<p><a href="{{ text.fields.read_more_link }}" class="{% if text.fields.read_more_cta %}link-cta-ubuntu{% else %}{% if text.fields.read_more_external %} external{% endif %}{% endif %}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} - {{ text.fields.header }} row link', 'eventValue' : undefined });">{% if text.fields.read_more_link_text %}{{text.fields.read_more_link_text}}{% else %}Read more{% endif %}{% if not text.fields.read_more_cta and not text.fields.read_more_external %}&nbsp;&rsaquo;{% endif %}</a></p>{% endif %}
+      {% if text.fields.read_more_link %}<p><a href="{{ text.fields.read_more_link }}" class="{% if text.fields.read_more_cta %}p-button--positive{% else %}{% if text.fields.read_more_external %} external{% endif %}{% endif %}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} - {{ text.fields.header }} row link', 'eventValue' : undefined });">{% if text.fields.read_more_link_text %}{{text.fields.read_more_link_text}}{% else %}Read more{% endif %}{% if not text.fields.read_more_cta and not text.fields.read_more_external %}&nbsp;&rsaquo;{% endif %}</a></p>{% endif %}
     </div>
     {% if forloop.counter|divisibleby:2 %}
     {% elif text.fields.header == "Ubuntu for LinuxONE and IBM Z" %}

--- a/templates/partner.html
+++ b/templates/partner.html
@@ -13,128 +13,126 @@
 {% endblock %}
 
 {% block content %}
-<div class="row strip hero{% if partner.links or partner.insights_tags %}{% else %} no-border{% endif %}">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col hero--text">
-            {% if partner.long_description %}
-            {{ partner.long_description|markdown }}
-            {% else %}
-            <h1>{{ partner.name }}</h1>
-            {{ partner.short_description|markdown }}
-            {% if partner.partner_website %}<p><a href="{{ partner.partner_website }}" class="external"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} website link', 'eventValue' : undefined });">{{ partner.name }} website</a></p>{% endif %}
-            {% endif %}
-        </div>
-        {% if not partner.long_description %}
-        <div class="four-col last-col align-center">
-            {% if partner.partner_website %}<a title="Vist the {{ partner.name }} website" href="{{ partner.partner_website }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} website logo link', 'eventValue' : undefined });"><img src="{{ partner.logo }}" alt="{{ partner.name }} logo" /></a>{% else %}<img src="{{ partner.logo }}" alt="{{ partner.name }} logo" />{% endif %}
-        </div>
-        {% endif %}
+<section class="p-strip p-hero">
+  <div class="row">
+    <div class="col-8 p-hero__text">
+      {% if partner.long_description %}
+      {{ partner.long_description|markdown }}
+      {% else %}
+      <h1>{{ partner.name }}</h1>
+      {{ partner.short_description|markdown }}
+      {% if partner.partner_website %}
+      <p><a href="{{ partner.partner_website }}" class="p-link--external"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} website link', 'eventValue' : undefined });">{{ partner.name }} website</a></p>
+      {% endif %}
+      {% endif %}
     </div>
-</div>
+    {% if not partner.long_description %}
+    <div class="col-4">
+      {% if partner.partner_website %}<a title="Vist the {{ partner.name }} website" href="{{ partner.partner_website }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} website logo link', 'eventValue' : undefined });"><img src="{{ partner.logo }}" alt="{{ partner.name }} logo" /></a>{% else %}<img src="{{ partner.logo }}" alt="{{ partner.name }} logo" />{% endif %}
+    </div>
+    {% endif %}
+  </div>
+</section>
 
 {% if partner.texts %}
 {% for text in partner.texts|dictsort:"pk" %}
-<div class="row strip{% if forloop.counter|divisibleby:2 %} strip-light{% endif %} cms-text{% if text.fields.html_class%} {{ text.fields.html_class }}{% endif %}">
-    <div class="strip-inner-wrapper">
-        <div class="twelve-col equal-height">
-            {% if forloop.counter|divisibleby:2 %}
-            <div class="four-col align-center align-vertically">
-                {% if text.fields.image_url %}<img src="{{ text.fields.image_url }}" alt="" class="cms-text--image" />{% endif %}
-            </div>
-            <div class="eight-col last-col">
-            {% else %}
-            <div class="eight-col cms-text--content">
-            {% endif %}
-                <h2>{{ text.fields.header }}</h2>
-                {{ text.fields.body|markdown }}
-                {% if text.fields.read_more_link %}<p><a href="{{ text.fields.read_more_link }}" class="{% if text.fields.read_more_cta %}link-cta-ubuntu{% else %}{% if text.fields.read_more_external %} external{% endif %}{% endif %}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} - {{ text.fields.header }} row link', 'eventValue' : undefined });">{% if text.fields.read_more_link_text %}{{text.fields.read_more_link_text}}{% else %}Read more{% endif %}{% if not text.fields.read_more_cta and not text.fields.read_more_external %}&nbsp;&rsaquo;{% endif %}</a></p>{% endif %}
-            </div>
-            {% if forloop.counter|divisibleby:2 %}
-            {% elif text.fields.header == "Ubuntu for LinuxONE and IBM Z" %}
-                {% include "templates/_ibm-card.html" %}
-            {% else %}
-            <div class="last-col four-col align-center align-vertically">
-                {% if text.fields.image_url %}<img src="{{ text.fields.image_url }}" alt="" class="cms-text--image" />{% endif %}
-            </div>
-            {% endif %}
-        </div>
-        {% if text.fields.insights_tag %}
-        <div class="row no-border">
-            <div class="six-col">
-                <h3>Further reading</h3>
-                <div id="articles-{{ forloop.counter }}"></div>
-            </div>
-        </div>
-        <script>
-          $(window).load(function(){
-            loadRSSFeed('articles-{{ forloop.counter }}', '{{ text.fields.insights_tag }}', 5);
-          });
-        </script>
-        {% endif %}
-        {% if text.fields.video_url %}
-        <div class="five-col prepend-one last-col">
-            <div class="video-container">
-                <iframe width="442" height="249" src="{{text.fields.video_url}}?rel=0&amp;wmode=opaque&amp;modestbranding=0" frameborder="0" allowfullscreen></iframe>
-            </div>
-        </div>
-        {% endif %}
+<section class="p-strip{% if forloop.counter|divisibleby:2 %}--light{% endif %} cms-text is-bordered{% if text.fields.html_class%} {{ text.fields.html_class }}{% endif %}">
+  <div class="row u-vertically-center">
+    {% if forloop.counter|divisibleby:2 %}
+    <div class="col-4 align-center align-vertically">
+      {% if text.fields.image_url %}<img src="{{ text.fields.image_url }}" alt="" class="cms-text--image" />{% endif %}
     </div>
-</div>
+    <div class="col-8 last-col">
+    {% else %}
+    <div class="col-8 cms-text--content">
+    {% endif %}
+      <h2>{{ text.fields.header }}</h2>
+      {{ text.fields.body|markdown }}
+      {% if text.fields.read_more_link %}<p><a href="{{ text.fields.read_more_link }}" class="{% if text.fields.read_more_cta %}link-cta-ubuntu{% else %}{% if text.fields.read_more_external %} external{% endif %}{% endif %}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} - {{ text.fields.header }} row link', 'eventValue' : undefined });">{% if text.fields.read_more_link_text %}{{text.fields.read_more_link_text}}{% else %}Read more{% endif %}{% if not text.fields.read_more_cta and not text.fields.read_more_external %}&nbsp;&rsaquo;{% endif %}</a></p>{% endif %}
+    </div>
+    {% if forloop.counter|divisibleby:2 %}
+    {% elif text.fields.header == "Ubuntu for LinuxONE and IBM Z" %}
+      {% include "templates/_ibm-card.html" %}
+    {% else %}
+    <div class="col-4">
+      {% if text.fields.image_url %}<img src="{{ text.fields.image_url }}" alt="" class="cms-text--image" />{% endif %}
+    </div>
+    {% endif %}
+  </div>
+</section>
+
+{% if text.fields.insights_tag or text.fields.video_url %}
+<section class="p-strip is-bordered">
+  <div class="row">
+    {% if text.fields.insights_tag %}
+    <div class="col-6">
+      <h3>Further reading</h3>
+      <div id="articles-{{ forloop.counter }}"></div>
+    </div>
+    <script>
+      $(window).load(function(){
+      loadRSSFeed('articles-{{ forloop.counter }}', '{{ text.fields.insights_tag }}', 5);
+      });
+    </script>
+    {% endif %}
+
+    {% if text.fields.video_url %}
+    <div class="col-6">
+      <div class="video-container">
+        <iframe width="442" height="249" src="{{text.fields.video_url}}?rel=0&amp;wmode=opaque&amp;modestbranding=0" frameborder="0" allowfullscreen></iframe>
+      </div>
+    </div>
+    {% endif %}
+  </div>
+</section>
+{% endif %}
 {% endfor %}
 {% endif %}
 
 {% if partner.quotes %}
-<div class="row strip">
-    <div class="strip-inner-wrapper equal-height">
-        {% for quote in partner.quotes %}
-        <div class="box six-col{% if forloop.counter|divisibleby:2 %} last-col{% endif %}">
-            <blockquote class="pull-quote">
-                <p><span>&ldquo;</span>{{ quote.fields.text }}<span>&rdquo;</span></p>
-                <p><cite>{{ quote.fields.attribution }}</cite></p>
-            </blockquote>
-        </div>
+<section class="p-strip">
+  <div class="row">
+    {% for quote in partner.quotes %}
+    <div class="box six-col{% if forloop.counter|divisibleby:2 %} last-col{% endif %}">
+      <blockquote class="pull-quote">
+        <p><span>&ldquo;</span>{{ quote.fields.text }}<span>&rdquo;</span></p>
+        <p><cite>{{ quote.fields.attribution }}</cite></p>
+      </blockquote>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{% endif %}
+
+{% if partner.links or partner.insights_tags %}
+<section class="p-strip">
+  <div class="row">
+    {% if partner.links %}
+    <div class="col-6">
+      <h2>Links</h2>
+      <ul class="no-bullets">
+        {% for link in partner.links %}
+        <li><a class="p-link--external" href="{{ link.fields.url }}"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} - {{ link.fields.text }} link', 'eventValue' : undefined });">{{ link.fields.text }}</a></li>
         {% endfor %}
+      </ul>
     </div>
-</div>
+    {% endif %}
+    {% if partner.insights_tags %}
+    <div class="col-6">
+      <h2>Further reading</h2>
+      <div id="insights"></div>
+    </div>
+    {% endif %}
+  </div>
+</section>
 {% endif %}
 
-{% if partner.links or partner.insights_tags %}
-<div class="row strip">
-    <div class="strip-inner-wrapper">
-{% endif %}
-        {% if partner.links %}
-        <div class="six-col">
-            <h2>Links</h2>
-            <ul class="no-bullets">
-                {% for link in partner.links %}
-                <li><a class="external" href="{{ link.fields.url }}"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Dedicated Partner Page Link', 'eventAction' : '{{ partner.name }} Page', 'eventLabel' : '{{ partner.name }} - {{ link.fields.text }} link', 'eventValue' : undefined });">{{ link.fields.text }}</a></li>
-                {% endfor %}
-            </ul>
-        </div>
-        {% endif %}
-        {% if partner.insights_tags %}
-        <div class="six-col last-col">
-            <h2>Further reading</h2>
-            <div id="insights"></div>
-        </div>
-        {% endif %}
-{% if partner.links or partner.insights_tags %}
-    </div>
-</div>
-{% endif %}
-
-<div class="row strip no-border strip-light">
-    <div class="strip-inner-wrapper">
-        {% include "templates/_contextual-footer.html" with no_wrapper=True %}
-    </div>
-</div>
+{% include "templates/_contextual-footer.html" with no_wrapper=True %}
 
 {% if partner.insights_tags %}
-  <script>
-    $(window).load(function(){
-      loadRSSFeed('insights', '{{ text.insights_tags }}', 5);
-    });
-  </script>
- {% endif %}
+<script>
+  document.addEventListener("DOMContentLoaded", loadRSSFeed('insights', '{{ text.insights_tags }}', 5));
+</script>
+{% endif %}
 
 {% endblock %}

--- a/templates/partner.html
+++ b/templates/partner.html
@@ -77,10 +77,8 @@
     {% endif %}
 
     {% if text.fields.video_url %}
-    <div class="col-6">
-      <div class="video-container">
-        <iframe width="442" height="249" src="{{text.fields.video_url}}?rel=0&amp;wmode=opaque&amp;modestbranding=0" frameborder="0" allowfullscreen></iframe>
-      </div>
+    <div class="col-6 u-align--center">
+      <iframe width="442" height="249" src="{{text.fields.video_url}}?rel=0&amp;wmode=opaque&amp;modestbranding=0" frameborder="0" allowfullscreen></iframe>
     </div>
     {% endif %}
   </div>

--- a/templates/templates/_contextual-footer.html
+++ b/templates/templates/_contextual-footer.html
@@ -22,15 +22,15 @@
       {% if level_2  == 'charm' %}
       <div class="feature-two col-6 p-divider__block">
         <h3>Further reading</h3>
-        <p><a class="p-link--external" href="https://insights.ubuntu.com/2016/02/21/charm-partner-programme/">Charm partner   programme datasheet</a></p>
+        <p><a class="external" href="https://blog.ubuntu.com/2016/02/21/charm-partner-programme/">Charm partner   programme datasheet</a></p>
       </div>
       {% else %}
       {% if level_2  == 'public-cloud' %}
       <div class="feature-two col-6 p-divider__block">
         <h3>Further reading</h3>
         <ul class="p-list">
-          <li cloud="p-list__item"><a class="p-link--external" href="https://insights.ubuntu.com/2016/10/07/ubuntu-certified-public-cloud-programme-2/">Ubuntu Certified Public Cloud programme datasheet</a></li>
-          <li cloud="p-list__item"><a class="p-link--external" href="https://insights.ubuntu.com/2016/01/14/5-reasons-you-should-only-use-certified-images-on-the-public-cloud/">Certified Ubuntu Cloud Guest eBook</a></li>
+          <li cloud="p-list__item"><a class="external" href="https://blog.ubuntu.com/2016/10/07/ubuntu-certified-public-cloud-programme-2/">Ubuntu Certified Public Cloud programme datasheet</a></li>
+          <li cloud="p-list__item"><a class="external" href="https://blog.ubuntu.com/2016/01/14/5-reasons-you-should-only-use-certified-images-on-the-public-cloud/">Certified Ubuntu Cloud Guest eBook</a></li>
         </ul>
       </div>
       {% else %}

--- a/templates/templates/_ibm-card.html
+++ b/templates/templates/_ibm-card.html
@@ -1,13 +1,14 @@
 
-<div class="four-col last-col">
-    <div class="p-card--partners">
-        <h3 class="p-card__title">Cloud and server news</h4>
-        <div class="p-card__content">
-            <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/32d396bf-LinuxONE-logo.png" alt="">
-            <a href="https://blog.ubuntu.com/2018/04/11/ubuntu-available-on-ibm-linuxone-rockhopper-ii">
-                <h3>Ubuntu available on IBM LinuxOne Rockhopper II&nbsp;&rsaquo;</h3>
-            </a>
-            <p>IBM and Canonical have ensured that Ubuntu is available on IBM Z and LinuxONE servers.</p>
-        </div>
+<div class="col-4">
+  <div class="p-card">
+    <h3 class="p-card__title p-muted-heading">Cloud and server news</h3>
+    <div class="p-card__content"">
+      <hr class="u-sv1">
+      <img src="https://assets.ubuntu.com/v1/32d396bf-LinuxONE-logo.png" alt="">
+      <a href="https://blog.ubuntu.com/2018/04/11/ubuntu-available-on-ibm-linuxone-rockhopper-ii">
+        <h4>Ubuntu available on IBM LinuxOne Rockhopper II&nbsp;&rsaquo;</h4>
+      </a>
+      <p>IBM and Canonical have ensured that Ubuntu is available on IBM Z and LinuxONE servers.</p>
     </div>
+  </div>
 </div>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -25,10 +25,10 @@
 
 <!-- site specific css -->
 <link rel="stylesheet" type="text/css" media="screen" href="{% versioned_static 'css/styles.css' %}" />
-<link rel="stylesheet" type="text/css" media="print" href="{% versioned_static 'css/core-print.css' %}" />
 
 <link type="text/plain" rel="author" href="{% versioned_static 'files/humans.txt' %}" />
 
+<script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
 {% block head_extra %}{% endblock %}
 
 </head>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -36,7 +36,7 @@
           <li class="p-list__item"><a href="https://www.ubuntu.com/">Ubuntu</a></li>
           <li class="p-list__item"><a href="https://www.ubuntu.com/support/plans-and-pricing">Ubuntu Advantage</a></li>
           <li class="p-list__item"><a href="https://www.canonical.com/">Canonical</a></li>
-          <li class="p-list__item"><a href="https://insights.ubuntu.com/">Press and resources</a></li>
+          <li class="p-list__item"><a href="https://blog.ubuntu.com/">Press and resources</a></li>
         </ul>
         </div>
       </div>


### PR DESCRIPTION
## Done

Updated the featured partner pages

## QA

- `./run`
- Go to /admincms/
- Create a new partner for IBM with the following fields:

![image](https://user-images.githubusercontent.com/118614/45025084-73a75680-b032-11e8-99ee-f5ec9c49d8e4.png)

- Attach a "text" object to the IBM partner - ensuring that the header is, exactly, "Ubuntu for LinuxONE and IBM Z"

![image](https://user-images.githubusercontent.com/118614/45025141-9d607d80-b032-11e8-99cb-499335ffbde8.png)

## Examples
Here are some examples of the featured partner pages with custom styles:


### Microsoft
![image](https://user-images.githubusercontent.com/118614/45025177-b36e3e00-b032-11e8-82dc-127672a146f5.png)

### IBM
![image](https://user-images.githubusercontent.com/118614/45025187-b9641f00-b032-11e8-8d1d-7079052c9780.png)

### AWS
![image](https://user-images.githubusercontent.com/118614/45025194-c08b2d00-b032-11e8-8930-ca42e6c479d8.png)

