### PR TITLE
OpenStack Interoperability Lab

### DIFF
--- a/templates/programmes/openstack.html
+++ b/templates/programmes/openstack.html
@@ -1,7 +1,7 @@
 {% extends "templates/base_index.html" %}
 
-{% block title %}Ubuntu OpenStack interoperability lab partners | {% endblock %}
-{% block meta_description %}Engage with the Ubuntu OpenStack interoperability lab (Ubuntu OIL) to develop and test your technologies’ interoperability with Ubuntu OpenStack and a range of software and hardware.{% endblock %}
+{% block title %}Ubuntu OpenStack Interoperability Lab partners | {% endblock %}
+{% block meta_description %}Engage with the Ubuntu OpenStack Interoperability Lab (Ubuntu OIL) to develop and test your technologies’ interoperability with Ubuntu OpenStack and a range of software and hardware.{% endblock %}
 {% block meta_keywords %}Cloud, OpenStack, Ubuntu, Server, Interoperability, testing, integration, ecosystem, UOIL, development, validation, affiliate, supporter, Technical Partner Progamme, lab, laboratory{% endblock %}
 
 {% block second_level_nav %}
@@ -12,8 +12,8 @@
 <section class="p-strip is-bordered">
   <div class="row u-vertically-center">
     <div class="col-8">
-      <h1 class="p-heading--two">Ubuntu OpenStack interoperability lab&nbsp;partners</h1>
-      <p>The Ubuntu OpenStack interoperability lab (OIL)  is an integration lab in which we test our cloud partners&rsquo; products in countless Ubuntu OpenStack configurations, over and over again. Currently we are working with over 3,500 combinations per month. </p>
+      <h1 class="p-heading--two">Ubuntu OpenStack Interoperability Lab&nbsp;partners</h1>
+      <p>The Ubuntu OpenStack Interoperability Lab (OIL)  is an integration lab in which we test our cloud partners&rsquo; products in countless Ubuntu OpenStack configurations, over and over again. Currently we are working with over 3,500 combinations per month. </p>
     </div>
     <div class="col-4 u-align--center">
       <img src="https://assets.ubuntu.com/v1/a7916513-picto-openstack.svg" alt="Ubuntu OpenStack medals" width="200">
@@ -25,7 +25,7 @@
   <div class="row u-vertically-center">
     <div class="col-7">
       <h2 class="p-heading--three">Proven integration testing</h2>
-      <p>Canonical has a long history of interoperability testing between OpenStack and Ubuntu.  To bring the benefits of our work to the rest of the ecosystem, we’ve launched the Ubuntu OpenStack interoperability lab, making it easier for you to QA the compatibility of your products with the world’s leading open cloud platform.</p>
+      <p>Canonical has a long history of interoperability testing between OpenStack and Ubuntu.  To bring the benefits of our work to the rest of the ecosystem, we’ve launched the Ubuntu OpenStack Interoperability Lab, making it easier for you to QA the compatibility of your products with the world’s leading open cloud platform.</p>
       <h2 class="p-heading--three">A sophisticated testing and integration&nbsp;process</h2>
       <p>Our process tests current and future developments of OpenStack against current and future developments of Ubuntu Server and Server LTS.
       As the ecosystem has grown, we’ve expanded it to include a wide array of guest operating systems, hypervisors, storage technologies,
@@ -34,14 +34,14 @@
       <p>It&rsquo;s never been more important to test your hardware and software against the entire OpenStack ecosystem.  So how do you get involved?</p>
     </div>
     <div class="col-5 u-align--center">
-      <img src="https://assets.ubuntu.com/v1/312f7dec-image-ubuntuopenstackinteroperabilitylab.svg" alt="Ubuntu OpenStack interoperability lab pictograms" class="u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/312f7dec-image-ubuntuopenstackinteroperabilitylab.svg" alt="" class="u-hide--small">
     </div>
   </div>
 </section>
 <section class="p-strip--light">
   <div class="row">
     <h2 class="p-heading--three">What&rsquo;s included?</h2>
-    <p>As a partner involved in the interoperability lab you can expect:</p>
+    <p>As a partner involved in the Interoperability Lab you can expect:</p>
   </div>
   <div class="row">
     <ul class="p-list is-split">


### PR DESCRIPTION
- Corrects “Openstack interoperability lab” to “OpenStack Interoperability Lab”, following [the style guide](https://wiki.canonical.com/Marketing/Style_guide)
- Removes unhelpful “OpenStack Interoperability Lab pictograms” alt text for image that is purely decorative