### PR TITLE
Remove OIL from homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}{% endblock %}
 {% block meta_description %}Find or become and Ubuntu partner, and benefit from the support of Canonical, the company set up to guide Ubuntu's enterprise adoption.{% endblock %}
-{% block meta_keywords %}Canonical, Ubuntu, partner, partnership, program, programme, carrier, telco, mobile, network, phone, smartphone, tablet, cloud, OpenStack, public cloud, infrastructure, guest, image, IaaS, PaaS, SaaS, server, ISV, IHV, OEM, ODM, software, hardware, enablement, certify, certified, certification, PC, laptop, desktop, Channel partners, VAR, channel, developer{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/151x2H8xmKQzy-gwEUlijTRbzyfnPomaVV00zjwbNW4g/edit#{% endblock %}
 
 {% block extra_body_class %}home full-width{% endblock %}
 
@@ -36,7 +36,7 @@
   <div class="row u-vertically-center">
     <div class="col-6">
         <h2 class="p-heading--three">World leaders in the cloud</h2>
-        <p>We partner with a wide range of cloud vendors, offering engineering assistance, support and ongoing <a href="/programmes/openstack">quality assurance</a> to the ecosystem that is fast developing around Ubuntu and OpenStack. As a result, Ubuntu is the now world&rsquo;s most popular OS for OpenStack, with over 60% of deployments worldwide. Meanwhile, the <a href="/programmes/public-cloud">Certified Public Cloud</a> programme, offers optimised Ubuntu images for users of the world&rsquo;s top public clouds. Two levels of partnership &mdash; Premier and Certified &mdash; give partners the flexibility to choose a level of involvement that best suits their needs.</p>
+        <p>We partner with a wide range of cloud vendors, offering engineering assistance, support and ongoing quality assurance to the ecosystem that is fast developing around Ubuntu and OpenStack. As a result, Ubuntu is the now world&rsquo;s most popular OS for OpenStack, with over 60% of deployments worldwide. Meanwhile, the <a href="/programmes/public-cloud">Certified Public Cloud</a> programme, offers optimised Ubuntu images for users of the world&rsquo;s top public clouds.</p>
     </div>
     <div class="col-6 u-align--center">
         <img src="{{ ASSET_SERVER_URL }}8149d09f-Service+View+-+zoom.png?h=332" alt="Juju" />


### PR DESCRIPTION
## Done

Removed the link to OIL, updated to match the copy doc

## QA

- download this branch
- ./run the server
- go to http://0.0.0.0:8003/
- compare to the [copy doc](https://docs.google.com/document/d/151x2H8xmKQzy-gwEUlijTRbzyfnPomaVV00zjwbNW4g/edit#heading=h.twzeocg9szb2)

## Issue / Card

Fixes #206

