### PR TITLE
Fix footer typo

### DIFF
--- a/templates/templates/_contextual-footer.html
+++ b/templates/templates/_contextual-footer.html
@@ -83,7 +83,7 @@
       </div>
       <div class="feature-two col-6 p-divider__block">
         <h3>Partner programmes</h3>
-        <p>Do you offer different services to you customers? Learn more about other Ubuntu partner programmes.</p>
+        <p>Do you offer different services to your customers? Learn more about other Ubuntu partner programmes.</p>
         <p><a href="/programmes">Partner programmes&nbsp;&rsaquo;</a></p>
       </div>
       {% endif %}


### PR DESCRIPTION
## Done

- Fixed a typo in the contextual footer s/you customers/your customers/

## QA

1. Download this branch
2. `./run` the site
3. Go to http://0.0.0.0:8003/
4. Look at the contextual footer and see the update

## Issue / Card

Fixes #187 

## Screenshots

![image](https://user-images.githubusercontent.com/441217/54084152-0815ad00-4325-11e9-9cab-7bfca98d8a0b.png)