### PR TITLE
Downgrade Django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 setuptools==65.5.1
 talisker[gunicorn]==0.21.3
-Django==4.2.1
+Django==4.0.10
 psycopg2-binary==2.9.6
 dj-database-url==0.5.0
 python-openid==2.2.5


### PR DESCRIPTION
Downgrade django to `4.0.10` to unbreak compatibility with postgres `10.x`.  Our old (ps4.5) database is using postgres 10.0, which is unsupported beyond Django 4.0. We can upgrade once more after decomissioning the old db.

## Done
- Downgraded django to the last version that supported postgres 10.x versions.

## QA

1. Wait for the demo to run
2. Check that the [demo-url](https://partners-ubuntu-com-291.demos.haus/partners.json) works. (Should just be an empty array)
